### PR TITLE
문서 수정 기능 마이그레이션

### DIFF
--- a/client/src/api/document.ts
+++ b/client/src/api/document.ts
@@ -3,11 +3,10 @@
 import {CACHE} from '@constants/cache';
 import {ENDPOINT} from '@constants/endpoint';
 import {RecentlyDocument, WikiDocument} from '@type/Document.type';
-import {http} from '@utils/http';
-import {revalidateTag} from 'next/cache';
+import {requestGet} from '@utils/http';
 
 export const getDocumentByTitle = async (title: string) => {
-  const docs = await http.get<WikiDocument>({
+  const docs = await requestGet<WikiDocument>({
     endpoint: `${ENDPOINT.getDocumentByTitle}/${title}`,
     next: {revalidate: CACHE.time.revalidate, tags: [CACHE.tag.getDocumentByTitle]},
   });
@@ -16,7 +15,7 @@ export const getDocumentByTitle = async (title: string) => {
 };
 
 export const getRandomDocument = async () => {
-  const docs = await http.get<WikiDocument>({
+  const docs = await requestGet<WikiDocument>({
     endpoint: ENDPOINT.getRandomDocument,
     next: {revalidate: CACHE.time.revalidate, tags: [CACHE.tag.getRandomDocument]},
   });
@@ -29,7 +28,7 @@ interface RecentlyDocumentsResponse {
 }
 
 export const getRecentlyDocuments = async () => {
-  const {documents} = await http.get<RecentlyDocumentsResponse>({
+  const {documents} = await requestGet<RecentlyDocumentsResponse>({
     endpoint: ENDPOINT.getRecentlyDocuments,
     next: {revalidate: CACHE.time.revalidate, tags: [CACHE.tag.getRecentlyDocuments]},
   });
@@ -45,18 +44,8 @@ export interface PostDocumentContent {
   documentBytes: number;
 }
 
-export const postDocument = async (document: PostDocumentContent) => {
-  const response = await http.post<WikiDocument>({
-    endpoint: ENDPOINT.postDocument,
-    body: document,
-  });
-  revalidateTag(CACHE.tag.getRecentlyDocuments);
-
-  return response;
-};
-
 export const searchDocument = async (referQuery: string) => {
-  const titles = await http.get<string[]>({
+  const titles = await requestGet<string[]>({
     endpoint: ENDPOINT.getDocumentSearch,
     queryParams: {
       keyWord: referQuery,

--- a/client/src/api/document.ts
+++ b/client/src/api/document.ts
@@ -8,7 +8,7 @@ import {requestGet} from '@utils/http';
 export const getDocumentByTitle = async (title: string) => {
   const docs = await requestGet<WikiDocument>({
     endpoint: `${ENDPOINT.getDocumentByTitle}/${title}`,
-    next: {revalidate: CACHE.time.revalidate, tags: [CACHE.tag.getDocumentByTitle]},
+    next: {revalidate: CACHE.time.revalidate, tags: [CACHE.tag.getDocumentByTitle(title)]},
   });
 
   return docs;

--- a/client/src/api/images.ts
+++ b/client/src/api/images.ts
@@ -25,9 +25,14 @@ const resizeFile = (file: File) =>
     Resizer.imageFileResizer(file, 640, 640, 'JPEG', 70, 0, uri => res(uri), 'file');
   });
 
-export async function uploadImages(albumName: string, uploadImageMetas: UploadImageMeta[]) {
-  const newMetas = await Promise.all(
-    uploadImageMetas.map(async imageMeta => {
+export type UploadImagesArgs = {
+  albumName: string;
+  uploadImageMetaList: UploadImageMeta[];
+};
+
+export async function uploadImages({albumName, uploadImageMetaList}: UploadImagesArgs) {
+  const newMetaList = await Promise.all(
+    uploadImageMetaList.map(async imageMeta => {
       const randomFileName = Math.random().toString(36).substr(2, 11);
       const resizedImage = (await resizeFile(imageMeta.file)) as File;
       const uploadImageKey = `${albumName}/${randomFileName}`;
@@ -47,5 +52,5 @@ export async function uploadImages(albumName: string, uploadImageMetas: UploadIm
     }),
   );
 
-  return newMetas;
+  return newMetaList;
 }

--- a/client/src/app/api/post-document/route.ts
+++ b/client/src/app/api/post-document/route.ts
@@ -1,0 +1,29 @@
+import {PostDocumentContent} from '@api/document';
+import {CACHE} from '@constants/cache';
+import {ENDPOINT} from '@constants/endpoint';
+import {WikiDocument} from '@type/Document.type';
+import {requestPost} from '@utils/http';
+import {revalidateTag} from 'next/cache';
+import {NextRequest, NextResponse} from 'next/server';
+
+const postDocument = async (document: PostDocumentContent) => {
+  const response = await requestPost<WikiDocument>({
+    endpoint: ENDPOINT.postDocument,
+    body: document,
+  });
+
+  revalidateTag(CACHE.tag.getRecentlyDocuments);
+  return response;
+};
+
+export const POST = async (request: NextRequest) => {
+  const document: PostDocumentContent = await request.json();
+
+  try {
+    await postDocument(document);
+
+    return NextResponse.json(document, {status: 200});
+  } catch (error) {
+    return NextResponse.json({error}, {status: 500});
+  }
+};

--- a/client/src/app/api/post-document/route.ts
+++ b/client/src/app/api/post-document/route.ts
@@ -1,3 +1,5 @@
+'use server';
+
 import {PostDocumentContent} from '@api/document';
 import {CACHE} from '@constants/cache';
 import {ENDPOINT} from '@constants/endpoint';

--- a/client/src/app/api/put-document/route.ts
+++ b/client/src/app/api/put-document/route.ts
@@ -20,7 +20,7 @@ const putDocument = async (document: PostDocumentContent) => {
   });
 
   revalidateTag(CACHE.tag.getRecentlyDocuments);
-  revalidateTag(CACHE.tag.getDocumentByTitle);
+  revalidateTag(CACHE.tag.getDocumentByTitle(document.title));
 
   return response;
 };
@@ -31,7 +31,7 @@ export const PUT = async (request: NextRequest) => {
   try {
     await putDocument(document);
 
-    return NextResponse.json({}, {status: 200});
+    return NextResponse.json(document, {status: 200});
   } catch (error) {
     return NextResponse.json({error}, {status: 500});
   }

--- a/client/src/app/api/put-document/route.ts
+++ b/client/src/app/api/put-document/route.ts
@@ -1,0 +1,38 @@
+'use server';
+
+import {PostDocumentContent} from '@api/document';
+
+import {WikiDocument} from '@type/Document.type';
+import {ENDPOINT} from '@constants/endpoint';
+import {requestPut} from '@utils/http';
+import {NextRequest, NextResponse} from 'next/server';
+import {revalidateTag} from 'next/cache';
+import {CACHE} from '@constants/cache';
+
+const putDocument = async (document: PostDocumentContent) => {
+  const response = await requestPut<WikiDocument>({
+    endpoint: `${ENDPOINT.updateDocument}/${document.title}`,
+    body: {
+      writer: document.writer,
+      contents: document.contents,
+      documentBytes: document.documentBytes,
+    },
+  });
+
+  revalidateTag(CACHE.tag.getRecentlyDocuments);
+  revalidateTag(CACHE.tag.getDocumentByTitle);
+
+  return response;
+};
+
+export const PUT = async (request: NextRequest) => {
+  const document: PostDocumentContent = await request.json();
+
+  try {
+    await putDocument(document);
+
+    return NextResponse.json({}, {status: 200});
+  } catch (error) {
+    return NextResponse.json({error}, {status: 500});
+  }
+};

--- a/client/src/app/wiki/[title]/edit/layout.tsx
+++ b/client/src/app/wiki/[title]/edit/layout.tsx
@@ -1,0 +1,9 @@
+const Layout = ({children}: React.PropsWithChildren) => {
+  return (
+    <section className="flex flex-col gap-6 w-full h-fit bg-white border-primary-100 border-solid border rounded-xl p-8 max-[768px]:p-4 max-[768px]:gap-3">
+      {children}
+    </section>
+  );
+};
+
+export default Layout;

--- a/client/src/app/wiki/[title]/edit/page.tsx
+++ b/client/src/app/wiki/[title]/edit/page.tsx
@@ -34,12 +34,7 @@ const Page = () => {
 
   return (
     document && (
-      <DocumentWriteContextProvider
-        mode="edit"
-        title={document.title}
-        writer={document.writer}
-        contents={document.contents}
-      >
+      <DocumentWriteContextProvider mode="edit" title={document.title} contents={document.contents}>
         <EditPage />
       </DocumentWriteContextProvider>
     )

--- a/client/src/app/wiki/[title]/edit/page.tsx
+++ b/client/src/app/wiki/[title]/edit/page.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import PostHeader from '@components/Write/PostHeader';
+import {DocumentWriteContextProvider, useDocumentWriteContextProvider} from '../../../../context/DocumentWriteContext';
+import TitleInputField from '@components/Write/TitleInputField';
+import TuiEditor from '@components/MarkdownEditor';
+import RelativeSearchTerms from '@components/Write/RelativeSearchTerms';
+import {useEffect, useState} from 'react';
+import {WikiDocument} from '@type/Document.type';
+import {useParams} from 'next/navigation';
+import {getDocumentByTitle} from '@api/document';
+import {useRelativeSearchTerms} from '@app/wiki/post/useRelativeSearchTerms';
+
+const EditPage = () => {
+  const {editorRef, initialContents} = useDocumentWriteContextProvider();
+  const {top, left, titles, onClick, showRelativeSearchTerms} = useRelativeSearchTerms({editorRef});
+
+  return (
+    <>
+      <PostHeader />
+      <TitleInputField disabled />
+      <TuiEditor initialValue={initialContents ?? null} />
+      <RelativeSearchTerms
+        showRelativeSearchTerms={showRelativeSearchTerms}
+        style={{top: `${top + 200}px`, left, width: 320}}
+        searchTerms={titles ?? []}
+        onClick={onClick}
+      />
+    </>
+  );
+};
+
+const Page = () => {
+  const {title} = useParams();
+
+  const [document, setDocument] = useState<WikiDocument>();
+
+  useEffect(() => {
+    const init = async () => {
+      if (typeof title === 'string') {
+        const data = await getDocumentByTitle(title);
+        setDocument(data);
+      }
+    };
+
+    init();
+  }, [title]);
+
+  return (
+    document && (
+      <DocumentWriteContextProvider
+        mode="edit"
+        title={document.title}
+        writer={document.writer}
+        contents={document.contents}
+      >
+        <EditPage />
+      </DocumentWriteContextProvider>
+    )
+  );
+};
+
+export default Page;

--- a/client/src/app/wiki/[title]/edit/page.tsx
+++ b/client/src/app/wiki/[title]/edit/page.tsx
@@ -5,11 +5,9 @@ import {DocumentWriteContextProvider, useDocumentWriteContextProvider} from '../
 import TitleInputField from '@components/Write/TitleInputField';
 import TuiEditor from '@components/MarkdownEditor';
 import RelativeSearchTerms from '@components/Write/RelativeSearchTerms';
-import {useEffect, useState} from 'react';
-import {WikiDocument} from '@type/Document.type';
 import {useParams} from 'next/navigation';
-import {getDocumentByTitle} from '@api/document';
 import {useRelativeSearchTerms} from '@app/wiki/post/useRelativeSearchTerms';
+import {useGetDocumentByTitle} from '@hooks/fetch/useGetDocumentByTitle';
 
 const EditPage = () => {
   const {editorRef, initialContents} = useDocumentWriteContextProvider();
@@ -32,19 +30,7 @@ const EditPage = () => {
 
 const Page = () => {
   const {title} = useParams();
-
-  const [document, setDocument] = useState<WikiDocument>();
-
-  useEffect(() => {
-    const init = async () => {
-      if (typeof title === 'string') {
-        const data = await getDocumentByTitle(title);
-        setDocument(data);
-      }
-    };
-
-    init();
-  }, [title]);
+  const {document} = useGetDocumentByTitle(title as string);
 
   return (
     document && (

--- a/client/src/app/wiki/[title]/page.tsx
+++ b/client/src/app/wiki/[title]/page.tsx
@@ -1,10 +1,21 @@
-import {getDocumentByTitle} from '@api/document';
+import {getDocumentByTitle, getRecentlyDocuments} from '@api/document';
 import DocumentContents from '@components/Document/DocumentContents';
 import DocumentFooter from '@components/Document/DocumentFooter';
 import DocumentHeader from '@components/Document/DocumentHeader';
+import {CACHE} from '@constants/cache';
 
 interface Props {
   params: {title: string};
+}
+
+export const revalidate = CACHE.time.revalidate;
+
+export const dynamicParams = true;
+
+export async function generateStaticParams() {
+  const documents = await getRecentlyDocuments();
+
+  return documents.map(({title}) => ({title}));
 }
 
 // next.js v15부터 params를 받기 위해 await를 사용해야 함

--- a/client/src/app/wiki/post/page.tsx
+++ b/client/src/app/wiki/post/page.tsx
@@ -35,7 +35,7 @@ const PostPage = () => {
 
 const Page = () => {
   return (
-    <DocumentWriteContextProvider>
+    <DocumentWriteContextProvider mode="post">
       <PostPage />
     </DocumentWriteContextProvider>
   );

--- a/client/src/components/Document/DocumentHeader.tsx
+++ b/client/src/components/Document/DocumentHeader.tsx
@@ -12,7 +12,7 @@ const DocumentHeader = ({title}: DocumentHeaderProps) => {
     <header className="max-md:flex-col-reverse max-md:gap-4 flex justify-between w-full">
       <DocumentTitle title={title} />
       <nav className="flex gap-2 max-md:hidden">
-        <Link href={`${URLS.wiki}/${URLS.edit}`}>
+        <Link href={`${URLS.wiki}/${title}${URLS.edit}`}>
           <Button style="tertiary" size="xs">
             편집하기
           </Button>
@@ -22,7 +22,7 @@ const DocumentHeader = ({title}: DocumentHeaderProps) => {
             편집로그
           </Button>
         </Link>
-        <Link href={`${URLS.wiki}/${URLS.post}`}>
+        <Link href={`${URLS.wiki}${URLS.post}`}>
           <Button style="primary" size="xs">
             작성하기
           </Button>

--- a/client/src/components/MarkdownEditor/index.tsx
+++ b/client/src/components/MarkdownEditor/index.tsx
@@ -5,7 +5,6 @@ const Editor = dynamic(() => import('@toast-ui/react-editor').then(mod => mod.Ed
 
 import {type Editor as EditorType, EditorProps} from '@toast-ui/react-editor';
 import '@toast-ui/editor/toastui-editor.css';
-import {useEffect, useState} from 'react';
 import {UploadImageMeta} from '@type/Document.type';
 import {useDocumentWriteContextProvider} from '../../context/DocumentWriteContext';
 

--- a/client/src/components/RecentlyEdit/index.tsx
+++ b/client/src/components/RecentlyEdit/index.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 
 const RecentlyEdit = async () => {
   const documents = await getRecentlyDocuments();
+
   return (
     <aside className="max-[1024px]:hidden flex flex-col w-60 h-fit bg-white border-primary-100 border-solid border rounded-xl">
       <h2 className="flex justify-center items-center w-full h-12 font-pretendard font-bold text-lg border-b border-primary-100 text-grayscale-800">

--- a/client/src/constants/cache.ts
+++ b/client/src/constants/cache.ts
@@ -5,7 +5,7 @@ export const CACHE = {
   },
   tag: {
     getDocuments: 'documents',
-    getDocumentByTitle: 'title',
+    getDocumentByTitle: (title: string) => `title:${decodeURI(title)}`,
     getRecentlyDocuments: 'recently',
     getDocumentLogs: 'logs',
     getSpecificDocumentLog: 'specificLog',

--- a/client/src/constants/cache.ts
+++ b/client/src/constants/cache.ts
@@ -4,11 +4,12 @@ export const CACHE = {
     revalidate: 30,
   },
   tag: {
-    getDocumentByTitle: 'get-document-by-title',
-    getRecentlyDocuments: 'get-recently-documents',
-    getDocumentLogs: 'get-document-logs',
-    getSpecificDocumentLog: 'get-specific-document-log',
-    getDocumentSearch: 'get-document-search',
-    getRandomDocument: 'get-random-document',
+    getDocuments: 'documents',
+    getDocumentByTitle: 'title',
+    getRecentlyDocuments: 'recently',
+    getDocumentLogs: 'logs',
+    getSpecificDocumentLog: 'specificLog',
+    getDocumentSearch: 'search',
+    getRandomDocument: 'random',
   },
 } as const;

--- a/client/src/hooks/fetch/useGetDocumentByTitle.ts
+++ b/client/src/hooks/fetch/useGetDocumentByTitle.ts
@@ -1,0 +1,13 @@
+'use client';
+
+import {getDocumentByTitle} from '@api/document';
+import {useFetch} from '@hooks/useFetch';
+import {WikiDocument} from '@type/Document.type';
+
+export const useGetDocumentByTitle = (title: string) => {
+  const {data} = useFetch<WikiDocument>(() => getDocumentByTitle(title));
+
+  return {
+    document: data,
+  };
+};

--- a/client/src/hooks/fetch/useGetDocumentByTitle.ts
+++ b/client/src/hooks/fetch/useGetDocumentByTitle.ts
@@ -3,9 +3,11 @@
 import {getDocumentByTitle} from '@api/document';
 import {useFetch} from '@hooks/useFetch';
 import {WikiDocument} from '@type/Document.type';
+import {useCallback} from 'react';
 
 export const useGetDocumentByTitle = (title: string) => {
-  const {data} = useFetch<WikiDocument>(() => getDocumentByTitle(title));
+  const getData = useCallback(() => getDocumentByTitle(title), [title]);
+  const {data} = useFetch<WikiDocument>(getData);
 
   return {
     document: data,

--- a/client/src/hooks/mutation/usePostDocument.ts
+++ b/client/src/hooks/mutation/usePostDocument.ts
@@ -1,0 +1,34 @@
+'use client';
+
+import {PostDocumentContent} from '@api/document';
+import {URLS} from '@constants/urls';
+import useMutation from '@hooks/useMutation';
+import {WikiDocument} from '@type/Document.type';
+import {requestPost} from '@utils/http';
+import {useRouter} from 'next/navigation';
+
+export const usePostDocument = () => {
+  const router = useRouter();
+
+  const postDocument = async (document: PostDocumentContent) => {
+    const newDocument = await requestPost<WikiDocument>({
+      baseUrl: process.env.NEXT_PUBLIC_BASE_URL,
+      endpoint: '/api/post-document',
+      body: document,
+    });
+
+    return newDocument;
+  };
+
+  const {mutate, isPending} = useMutation<PostDocumentContent, WikiDocument>({
+    mutationFn: postDocument,
+    onSuccess: document => {
+      router.push(`${URLS.wiki}/${document.title}`);
+    },
+  });
+
+  return {
+    postDocument: mutate,
+    isPostPending: isPending,
+  };
+};

--- a/client/src/hooks/mutation/usePutDocument.ts
+++ b/client/src/hooks/mutation/usePutDocument.ts
@@ -1,0 +1,35 @@
+'use client';
+
+import {PostDocumentContent} from '@api/document';
+import {URLS} from '@constants/urls';
+import useMutation from '@hooks/useMutation';
+import {WikiDocument} from '@type/Document.type';
+import {requestPut} from '@utils/http';
+import {useRouter} from 'next/navigation';
+
+export const usePutDocument = () => {
+  const router = useRouter();
+
+  const putDocument = async (document: PostDocumentContent) => {
+    const editDocument = await requestPut<WikiDocument>({
+      baseUrl: process.env.NEXT_PUBLIC_BASE_URL,
+      endpoint: '/api/put-document',
+      body: document,
+    });
+
+    return editDocument;
+  };
+
+  const {mutate, isPending} = useMutation<PostDocumentContent, WikiDocument>({
+    mutationFn: putDocument,
+    onSuccess: document => {
+      router.push(`${URLS.wiki}/${document.title}`);
+      router.refresh();
+    },
+  });
+
+  return {
+    putDocument: mutate,
+    isPutPending: isPending,
+  };
+};

--- a/client/src/hooks/useFetch.ts
+++ b/client/src/hooks/useFetch.ts
@@ -1,0 +1,30 @@
+'use client';
+
+import {useEffect, useState} from 'react';
+
+export const useFetch = <T>(fetchFunction: () => Promise<T>) => {
+  const [data, setData] = useState<T | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        setIsLoading(true);
+        const response = await fetchFunction();
+        setData(response);
+        setErrorMessage(null);
+      } catch (error) {
+        if (error instanceof Error) {
+          setErrorMessage(error.message);
+        }
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchData();
+  }, [fetchFunction]);
+
+  return {data, isLoading, errorMessage};
+};

--- a/client/src/hooks/useMutation.ts
+++ b/client/src/hooks/useMutation.ts
@@ -1,0 +1,50 @@
+'use client';
+
+import {useState} from 'react';
+
+type MutationFn<TVariables, TData> = (variables: TVariables) => Promise<TData>;
+type OnSuccess<TData> = (data: TData) => void;
+type OnError = (error: unknown) => void;
+
+interface UseMutationArgs<TVariables, TData> {
+  mutationFn: MutationFn<TVariables, TData>;
+  onSuccess?: OnSuccess<TData>;
+  onError?: OnError;
+}
+
+const useMutation = <TVariables = void, TData = unknown>({
+  mutationFn,
+  onSuccess,
+  onError,
+}: UseMutationArgs<TVariables, TData>) => {
+  const [isPending, setIsPending] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [data, setData] = useState<TData | null>(null);
+
+  const mutate = async (variables: TVariables) => {
+    setIsPending(true);
+    setErrorMessage(null);
+
+    try {
+      const data = await mutationFn(variables);
+      setData(data);
+      if (onSuccess) onSuccess(data);
+    } catch (err) {
+      if (err instanceof Error) {
+        setErrorMessage(err.message);
+        if (onError) onError(err);
+      }
+    } finally {
+      setIsPending(false);
+    }
+  };
+
+  return {
+    mutate,
+    data,
+    isPending,
+    errorMessage,
+  };
+};
+
+export default useMutation;

--- a/client/src/import-env.d.ts
+++ b/client/src/import-env.d.ts
@@ -1,6 +1,7 @@
 declare namespace NodeJS {
   interface ProcessEnv {
     NEXT_PUBLIC_API_BASE_URL: string;
+    NEXT_PUBLIC_BASE_URL: string;
     NEXT_PUBLIC_BUCKET_NAME: string;
     NEXT_PUBLIC_BUCKET_REGION: string;
     NEXT_PUBLIC_ACCESS_KEY: string;

--- a/client/src/utils/getEditorContents.ts
+++ b/client/src/utils/getEditorContents.ts
@@ -1,0 +1,10 @@
+import {EditorRef} from '@type/Editor.type';
+
+export const getEditorContents = (editorRef: EditorRef): string => {
+  if (editorRef.current) {
+    const instance = editorRef.current?.getInstance();
+    const contents = instance.getMarkdown();
+    return contents;
+  }
+  return '';
+};

--- a/client/src/utils/http.ts
+++ b/client/src/utils/http.ts
@@ -1,3 +1,5 @@
+'use server';
+
 type Method = 'GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE';
 
 type HeadersType = [string, string][] | Record<string, string> | Headers;
@@ -26,28 +28,29 @@ type CreateRequestInitProps = {
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
 
-export const http = {
-  get: async <T>({headers = {}, ...args}: HttpMethodArgs): Promise<T> => {
-    return await request<T>({
-      ...args,
-      method: 'GET',
-      headers,
-    });
-  },
-  post: async <T>({headers = {}, ...args}: HttpMethodArgs): Promise<T> => {
-    return await request<T>({
-      ...args,
-      method: 'POST',
-      headers,
-    });
-  },
-  put: async <T>({headers = {}, ...args}: HttpMethodArgs): Promise<T> => {
-    return await request<T>({
-      ...args,
-      method: 'PUT',
-      headers,
-    });
-  },
+export const requestGet = async <T>({headers = {}, ...args}: HttpMethodArgs): Promise<T> => {
+  return await request<T>({
+    ...args,
+    method: 'GET',
+    headers,
+    cache: args.cache ?? 'no-cache',
+  });
+};
+
+export const requestPost = async <T>({headers = {}, ...args}: HttpMethodArgs): Promise<T> => {
+  return await request<T>({
+    ...args,
+    method: 'POST',
+    headers,
+  });
+};
+
+export const requestPut = async <T>({headers = {}, ...args}: HttpMethodArgs): Promise<T> => {
+  return await request<T>({
+    ...args,
+    method: 'PUT',
+    headers,
+  });
 };
 
 const objectToQueryString = (params: ObjectQueryParams): string => {
@@ -65,11 +68,10 @@ const prepareRequest = ({baseUrl = API_BASE_URL, method, endpoint, headers, body
   return {url, requestInit};
 };
 
-const createRequestInit = ({method, headers, body, next, cache}: CreateRequestInitProps) => {
+const createRequestInit = ({method, headers, body, next}: CreateRequestInitProps) => {
   const requestInit: RequestInit = {
     credentials: 'include',
     method,
-    cache: cache ?? 'default',
     next,
   };
 

--- a/client/src/utils/http.ts
+++ b/client/src/utils/http.ts
@@ -33,7 +33,7 @@ export const requestGet = async <T>({headers = {}, ...args}: HttpMethodArgs): Pr
     ...args,
     method: 'GET',
     headers,
-    cache: args.cache ?? 'no-cache',
+    cache: args.cache ?? 'force-cache',
   });
 };
 

--- a/client/src/utils/http.ts
+++ b/client/src/utils/http.ts
@@ -3,14 +3,10 @@ type Method = 'GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE';
 type HeadersType = [string, string][] | Record<string, string> | Headers;
 type ObjectQueryParams = Record<string, string | number | boolean>;
 
-type httpArgs = {
+type httpArgs = CreateRequestInitProps & {
   baseUrl?: string;
   endpoint: string;
-  headers?: HeadersType;
-  body?: BodyInit | object | null;
   queryParams?: ObjectQueryParams;
-  method: Method;
-  next?: NextFetchRequestConfig;
 };
 
 type HttpMethodArgs = Omit<httpArgs, 'method'>;
@@ -24,6 +20,7 @@ type CreateRequestInitProps = {
   body?: BodyInit | object | null;
   method: Method;
   headers?: HeadersType;
+  cache?: RequestCache;
   next?: NextFetchRequestConfig;
 };
 
@@ -68,10 +65,11 @@ const prepareRequest = ({baseUrl = API_BASE_URL, method, endpoint, headers, body
   return {url, requestInit};
 };
 
-const createRequestInit = ({method, headers, body, next}: CreateRequestInitProps) => {
+const createRequestInit = ({method, headers, body, next, cache}: CreateRequestInitProps) => {
   const requestInit: RequestInit = {
     credentials: 'include',
     method,
+    cache: cache ?? 'default',
     next,
   };
 

--- a/client/src/utils/replaceLocalUrlToS3Url.ts
+++ b/client/src/utils/replaceLocalUrlToS3Url.ts
@@ -1,0 +1,10 @@
+import {UploadImageMeta} from '@type/Document.type';
+
+export const replaceLocalUrlToS3Url = (contents: string, imageMetaList: UploadImageMeta[]) => {
+  let newContents = contents;
+  imageMetaList.forEach(({objectURL, s3URL}) => {
+    newContents = newContents.replace(objectURL, s3URL);
+  });
+
+  return newContents;
+};

--- a/client/src/utils/validation/title.ts
+++ b/client/src/utils/validation/title.ts
@@ -1,6 +1,6 @@
+import {requestGet} from '@utils/http';
 import {ENDPOINT} from './../../constants/endpoint';
 import {ErrorInfo, WikiDocument} from '@type/Document.type';
-import {http} from '@utils/http';
 
 export const validateTitleOnChange = (title: string) => {
   const errorInfo: ErrorInfo = {
@@ -26,7 +26,7 @@ export const validateTitleOnBlur = async (title: string) => {
   };
 
   try {
-    await http.get<WikiDocument>({
+    await requestGet<WikiDocument>({
       endpoint: `${ENDPOINT.getDocumentByTitle}/${title}`,
     });
     errorInfo.errorMessage = '이미 있는 문서입니다.';


### PR DESCRIPTION
## issue

- close #5 

## 구현 사항
### 문서 수정 기능 구현
![image](https://github.com/user-attachments/assets/a6d540b7-fdb9-446a-8689-46694089be5b)

문서를 수정하는 기능을 옮겨왔습니다. 역시 제목은 수정할 수 없으며 편집자와 내용을 변경하여 작성완료를 누르면 문서가 수정됩니다.

### dynamic path ISR 렌더링
크루위키는 /wiki/ 하위에 닉네임이 오는 구조입니다. 이런 구조에서 ISR을 활용하려면 /wiki/쿠키, /wiki/대문, /wiki/토다리 이런 문서들을 서버에서 미리 만들어두고 요청 시 응답을 내려줘야 합니다.
이 작업을 하기 위해 generateStaticParams라는 next에서 미리 정의된 함수를 사용하게 됩니다.

```ts
export async function generateStaticParams() {
  const documents = await getRecentlyDocuments();

  return documents.map(({title}) => ({title}));
}
```

사전 빌드 작업에서 최근 문서 정보를 들고 와서 크루위키에 등록된 제목을 추출합니다. 그 뒤 Page함수에서 하나하나 서버로 요청하여 문서마다 완성된 문서를 만들어두게 됩니다.

그리고 상단에 아래 두 개를 선언하게 됩니다.
revalidate는 재검증 시간이며 특정 시간이 지나면 서버에서 다시 html을 만들게 됩니다.
dynamicParams는 generateStaticParams에 정의되지 않은 params가 왔을 때 어떻게 처리할 것인지 정해줍니다. true로 설정한다는 것은 대체 페이지를 보여주겠다는 의미가 됩니다. (fallback은 다음 이슈에서 처리하겠습니다)

```ts
export const revalidate = CACHE.time.revalidate;
export const dynamicParams = true;
```

### on demand revalidation
사용자가 문서를 수정하면 put 요청이 일어나서 데이터가 바뀌게 됩니다. 그 때 저번 이슈에 이어서 revalidateTag를 이용하여 요청 후 revalidate를 수행하게 하여 서버에서 수정된 문서를 다시 불러올 수 있도록 구현했습니다.

여기서 동적 path와 on demand revalidation 사이에서 많이 헤매서 빠르게 구현하기 힘들었습니다.
최근 수정된 문서 목록은 수정된 데이터가 바로 보였으나, 정작 수정한 문서는 이전 데이터가 보인다는 문제였습니다.

기존에는 아래처럼 캐시 태그를 문서:title로 저장하고 revalidation을 revalidateTag(`${CACHE.tag.getDocumentByTitle}:${title}`)로 호출하면 각 문서에 맞는 캐시가 무효화되어 서버에서 다시 만들 줄 알았습니다.

```ts
export const getDocumentByTitle = async (title: string) => {
  const docs = await requestGet<WikiDocument>({
    endpoint: `${ENDPOINT.getDocumentByTitle}/${title}`,
    next: {revalidate: CACHE.time.revalidate, tags: [`${CACHE.tag.getDocumentByTitle}:${title}`]},
  });

  return docs;
};
```

그러나 전혀 무효화가 일어나지 않았고 revalidation 시간이 지나고 나서야 새로운 데이터를 반영한 html을 불러오게 됐던 것입니다.

이것으로 한참을 헤매다 발견한 해결책은 정말 어이없게도 **한글 인코딩**이었습니다........
tag에 한글을 넣어줄 때 '문서제목'이 들어가는 것이 아니라 인코딩된 값으로 들어가서 revalidate 해줘도 작동하지 않았던 것이었습니다.

그래서 tag에 decodeURI() 사용해주니.. 바로 특정 문서만 재검증이 가능했습니다... (이거 때문에 며칠을 헤맸는데..ㅜ)


### 클라이언트 컴포넌트에서 변경 요청할 때 base url에 대해서
클라이언트 컴포넌트에서 fetch를 수행하면 바로 백엔드 api로 요청이 가는 줄 알았습니다.
하지만 그렇지 않더라구요.. 먼저 클라이언트 서버로 요청을 한 후에 거기에서 백엔드 api로 요청해야 정상적으로 동작함을 확인할 수 있었습니다.

그래서 백엔드 api로 요청하기 전 클라이언트 서버로 요청을 하는 fetch를 한 번 더 작성해줘야 했습니다.
app router에서는 api route 기능을 제공하는데 app 디렉터리에 api 디렉터리를 추가해서 원하는 endpoint를 디렉터리로 작성한 후 route.ts파일을 생성하면, http://baseurl/api/endpoint로 fetch 요청을 할 수 있게 됩니다.

메서드 이름은 http method 이름이며 인자로 request, response를 받을 수 있습니다.
이 안에서 백엔드 api로 호출해야 내가 원하는 base url로 요청을 할 수 있습니다.

```ts
export const POST = async (request: NextRequest) => {
  const document: PostDocumentContent = await request.json();

  try {
    await postDocument(document);

    return NextResponse.json(document, {status: 200});
  } catch (error) {
    return NextResponse.json({error}, {status: 500});
  }
};
```

post는 우연히 백엔드에서 http://localhost:3000/api~로 요청이 와도 등록이 되게 열어둔 것 같지만 put을 실행하자마자 아무런 요청이 되지 않은 것을 발견한 후에 알게 되어 api route를 적용하니 정상적으로 요청이 되었습니다.

다시 한 번 기억
클라이언트 컴포넌트에서 요청을 보낼 때는 클라이언트 서버를 한 번 거쳐서 요청해야 한다.


### useFetch, useMutation custom hook 제작
클라이언트 컴포넌트에서 api를 호출할 때 사용하는 커스텀 훅을 제작했습니다.
loading과 pending 상태를 한 곳에서 관리하기 위함이고, mutation의 경우 onSuccess, onError 콜백을 넣어서 요청이 성공한 후, 요청이 실패한 후 액션을 취할 수 있도록 넣어줬습니다.



## 🫡 참고사항
### 다음 작업은 문서 수정 로그를 확인하는 기능입니다.

