### PR TITLE
문서 편집 로그 마이그레이션

### DIFF
--- a/client/src/api/document.ts
+++ b/client/src/api/document.ts
@@ -2,7 +2,7 @@
 
 import {CACHE} from '@constants/cache';
 import {ENDPOINT} from '@constants/endpoint';
-import {RecentlyDocument, WikiDocument} from '@type/Document.type';
+import {RecentlyDocument, WikiDocument, WikiDocumentLogSummary} from '@type/Document.type';
 import {requestGet} from '@utils/http';
 
 export const getDocumentByTitle = async (title: string) => {
@@ -12,6 +12,17 @@ export const getDocumentByTitle = async (title: string) => {
   });
 
   return docs;
+};
+
+export const getDocumentLogsByTitle = async (title: string) => {
+  const logs = await requestGet<WikiDocumentLogSummary[]>({
+    endpoint: ENDPOINT.getDocumentLogsByTitle(title),
+    next: {revalidate: CACHE.time.revalidate, tags: [CACHE.tag.getDocumentLogsByTitle(title)]},
+  });
+
+  return logs.sort((a: WikiDocumentLogSummary, b: WikiDocumentLogSummary) =>
+    a.generateTime <= b.generateTime ? 1 : -1,
+  );
 };
 
 export const getRandomDocument = async () => {

--- a/client/src/api/document.ts
+++ b/client/src/api/document.ts
@@ -2,7 +2,7 @@
 
 import {CACHE} from '@constants/cache';
 import {ENDPOINT} from '@constants/endpoint';
-import {RecentlyDocument, WikiDocument, WikiDocumentLogSummary} from '@type/Document.type';
+import {RecentlyDocument, WikiDocument, WikiDocumentLogDetail, WikiDocumentLogSummary} from '@type/Document.type';
 import {requestGet} from '@utils/http';
 
 export const getDocumentByTitle = async (title: string) => {
@@ -23,6 +23,15 @@ export const getDocumentLogsByTitle = async (title: string) => {
   return logs.sort((a: WikiDocumentLogSummary, b: WikiDocumentLogSummary) =>
     a.generateTime <= b.generateTime ? 1 : -1,
   );
+};
+
+export const getSpecificDocumentLog = async (logId: number) => {
+  const response = await requestGet<WikiDocumentLogDetail>({
+    endpoint: ENDPOINT.getSpecificDocumentLog(logId),
+    next: {revalidate: CACHE.time.revalidate, tags: [CACHE.tag.getSpecificDocumentLog(logId)]},
+  });
+
+  return response;
 };
 
 export const getRandomDocument = async () => {

--- a/client/src/app/wiki/[title]/log/[logId]/page.tsx
+++ b/client/src/app/wiki/[title]/log/[logId]/page.tsx
@@ -1,0 +1,25 @@
+import {getSpecificDocumentLog} from '@api/document';
+import DocumentContents from '@components/Document/DocumentContents';
+import DocumentFooter from '@components/Document/DocumentFooter';
+import DocumentHeader from '@components/Document/DocumentHeader';
+
+interface Props {
+  params: {title: string; logId: string};
+}
+
+const Page = async ({params}: Props) => {
+  const {title, logId} = await params;
+  const document = await getSpecificDocumentLog(Number(logId));
+
+  return (
+    <section className="flex flex-col items-center w-full gap-6">
+      <div className="flex flex-col gap-6 w-full h-fit bg-white border-primary-100 border-solid border rounded-xl p-8 max-[768px]:p-4 max-[768px]:gap-2 ">
+        <DocumentHeader title={decodeURI(title)} />
+        <DocumentContents contents={document.contents} />
+      </div>
+      <DocumentFooter generateTime={document.generateTime} />
+    </section>
+  );
+};
+
+export default Page;

--- a/client/src/app/wiki/[title]/logs/LogContent.tsx
+++ b/client/src/app/wiki/[title]/logs/LogContent.tsx
@@ -1,0 +1,36 @@
+import {URLS} from '@constants/urls';
+import {WikiDocumentLogSummary} from '@type/Document.type';
+import timeConverter from '@utils/TimeConverter';
+import Link from 'next/link';
+
+type LogContentProps = {
+  title: string;
+  summary: WikiDocumentLogSummary;
+};
+
+export const LogContent = ({title, summary}: LogContentProps) => {
+  const {logId, version, generateTime, documentBytes, writer} = summary;
+
+  return (
+    <Link
+      href={`${URLS.wiki}/${title}/log/${logId}`}
+      passHref
+      className="flex items-center justify-center w-full gap-2 px-2 py-4 border border-primary-100 rounded-2xl font-pretendard text-md  text-grayscale-800 md:gap-8"
+    >
+      <div className="w-10">
+        <p className="w-full text-center">{version}</p>
+      </div>
+      <div className="grow text-center flex justify-center">
+        <p className="w-[144px] text-center md:w-full">
+          {timeConverter(generateTime, 'YYYY년 M월 D일 (ddd) HH:mm:ss')}
+        </p>
+      </div>
+      <div className="w-16">
+        <p className="w-full text-center">{`${documentBytes ?? 0}B`}</p>
+      </div>
+      <div className="w-16">
+        <p className="w-full text-center">{writer}</p>
+      </div>
+    </Link>
+  );
+};

--- a/client/src/app/wiki/[title]/logs/LogsHeader.tsx
+++ b/client/src/app/wiki/[title]/logs/LogsHeader.tsx
@@ -1,0 +1,27 @@
+import Button from '@components/Button';
+import {URLS} from '@constants/urls';
+import Link from 'next/link';
+
+type LogsHeaderProps = {
+  title: string;
+};
+
+export const LogsHeader = ({title}: LogsHeaderProps) => {
+  return (
+    <header className="flex justify-between w-full">
+      <h1 className="font-bm text-3xl text-grayscale-800">편집로그</h1>
+      <fieldset className="flex gap-2">
+        <Link href={`${URLS.wiki}/${title}`} passHref>
+          <Button style="tertiary" size="xs">
+            돌아가기
+          </Button>
+        </Link>
+        <Link href={`${URLS.wiki}/${title}${URLS.edit}`} passHref>
+          <Button style="primary" size="xs">
+            편집하기
+          </Button>
+        </Link>
+      </fieldset>
+    </header>
+  );
+};

--- a/client/src/app/wiki/[title]/logs/layout.tsx
+++ b/client/src/app/wiki/[title]/logs/layout.tsx
@@ -1,0 +1,27 @@
+import {LogsHeader} from './LogsHeader';
+import DocumentFooter from '@components/Document/DocumentFooter';
+import {getDocumentByTitle} from '@api/document';
+
+type Props = React.PropsWithChildren & {
+  params: {title: string};
+};
+
+const Layout = async ({children, params}: Props) => {
+  const {title} = await params;
+  const document = await getDocumentByTitle(title);
+
+  return (
+    document && (
+      <section className="flex flex-col items-center w-full gap-6">
+        <div className="flex flex-col gap-6 w-full h-fit min-h-[864px] bg-white border-primary-100 border-solid border rounded-xl p-8 max-md:p-4 max-md:gap-2">
+          <LogsHeader title={document.title} />
+          <h1 className="font-bm text-2xl text-grayscale-800">{document.title}</h1>
+          {children}
+        </div>
+        <DocumentFooter generateTime={document.generateTime} />
+      </section>
+    )
+  );
+};
+
+export default Layout;

--- a/client/src/app/wiki/[title]/logs/page.tsx
+++ b/client/src/app/wiki/[title]/logs/page.tsx
@@ -1,0 +1,35 @@
+import {LogContent} from './LogContent';
+import {getDocumentLogsByTitle} from '@api/document';
+
+interface Props {
+  params: {title: string};
+}
+
+const Page = async ({params}: Props) => {
+  const {title} = await params;
+  const documentLogs = await getDocumentLogsByTitle(title);
+
+  return (
+    <div className="flex flex-col w-full gap-4">
+      <div className="flex w-full gap-2 px-2 py-3 rounded-2xl bg-primary-50 font-pretendard text-md text-grayscale-800 md:gap-8">
+        <div className="w-10 ">
+          <p className="w-full text-center font-bold">버전</p>
+        </div>
+        <div className="grow">
+          <p className="w-full text-center font-bold">생성일시</p>
+        </div>
+        <div className="w-16 ">
+          <p className="w-full text-center font-bold">문서 크기</p>
+        </div>
+        <div className="w-16 ">
+          <p className="w-full text-center font-bold">편집자</p>
+        </div>
+      </div>
+      <div className="flex flex-col gap-4">
+        {documentLogs?.map(docs => <LogContent key={docs.logId} title={title as string} summary={docs} />)}
+      </div>
+    </div>
+  );
+};
+
+export default Page;

--- a/client/src/constants/cache.ts
+++ b/client/src/constants/cache.ts
@@ -8,7 +8,7 @@ export const CACHE = {
     getDocumentByTitle: (title: string) => `title:${decodeURI(title)}`,
     getRecentlyDocuments: 'recently',
     getDocumentLogsByTitle: (title: string) => `logs:${decodeURI(title)}`,
-    getSpecificDocumentLog: 'specificLog',
+    getSpecificDocumentLog: (logId: number) => `specificLog:${logId}`,
     getDocumentSearch: 'search',
     getRandomDocument: 'random',
   },

--- a/client/src/constants/cache.ts
+++ b/client/src/constants/cache.ts
@@ -7,7 +7,7 @@ export const CACHE = {
     getDocuments: 'documents',
     getDocumentByTitle: (title: string) => `title:${decodeURI(title)}`,
     getRecentlyDocuments: 'recently',
-    getDocumentLogs: 'logs',
+    getDocumentLogsByTitle: (title: string) => `logs:${decodeURI(title)}`,
     getSpecificDocumentLog: 'specificLog',
     getDocumentSearch: 'search',
     getRandomDocument: 'random',

--- a/client/src/constants/endpoint.ts
+++ b/client/src/constants/endpoint.ts
@@ -5,6 +5,6 @@ export const ENDPOINT = {
   getRandomDocument: '/document',
   getRecentlyDocuments: '/document/recent',
   getDocumentSearch: '/document/search',
-  getDocumentLogs: (title: string) => `document/${title}/log`,
-  getSpecificDocumentLog: (logId: number) => `document/log/${logId}`,
+  getDocumentLogsByTitle: (title: string) => `/document/${title}/log`,
+  getSpecificDocumentLog: (logId: number) => `/document/log/${logId}`,
 } as const;


### PR DESCRIPTION
## issue

- close #9 

## 구현 사항
### 문서 편집 로그 목록 마이그레이션
getDocumentLogsByTitle api를 서버에서 호출하여 편집 목록을 확인할 수 있도록 옮겨왔습니다.
(아직 static 처리는 아직. 이건 마이그레이션 이후 조정할 예정)

![image](https://github.com/user-attachments/assets/6a89691c-41e4-4f47-be2c-525ec4239b66)


### 문서 편집 로그 상세 마이그레이션
getSpecificDocumentLog api를 서버에서 호출하여 로그 상세를 확인할 수 있도록 옮겨왔습니다.
(이것도 static 처리는 아직. 이건 마이그레이션 이후 조정할 예정)

![image](https://github.com/user-attachments/assets/159e8008-e015-4fec-b3c4-4df7146f8a16)


## 🫡 참고사항
### 다음 이슈는 검색 창과 자동 완성, 랜덤문서 기능 마이그레이션입니다.
