### PR TITLE
오류 페이지 마이그레이션

### DIFF
--- a/client/src/app/wiki/[title]/error.tsx
+++ b/client/src/app/wiki/[title]/error.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import Button from '@components/Button';
+import DocumentTitle from '@components/Document/DocumentTitle';
+import {URLS} from '@constants/urls';
+import {useParams, useRouter} from 'next/navigation';
+
+const Error = () => {
+  const {title} = useParams();
+  const router = useRouter();
+
+  const goPostPage = () => {
+    router.push(`${URLS.wiki}${URLS.post}`);
+  };
+
+  return (
+    <div className="flex flex-col gap-6 w-full h-fit min-h-[864px] bg-white border-primary-100 border-solid border rounded-xl p-8 max-md:p-4">
+      <header className="max-[768px]:gap-4 flex justify-between w-full">
+        <DocumentTitle title={decodeURI(title as string)} />
+        <fieldset className="flex gap-2">
+          <Button style="primary" size="xs" onClick={goPostPage}>
+            작성하기
+          </Button>
+        </fieldset>
+      </header>
+      <h1 className="font-bm text-2xl text-grayscale-800">존재하지 않는 문서에요.</h1>
+    </div>
+  );
+};
+
+export default Error;

--- a/client/src/app/wiki/[title]/log/[logId]/page.tsx
+++ b/client/src/app/wiki/[title]/log/[logId]/page.tsx
@@ -2,6 +2,7 @@ import {getSpecificDocumentLog} from '@api/document';
 import DocumentContents from '@components/Document/DocumentContents';
 import DocumentFooter from '@components/Document/DocumentFooter';
 import DocumentHeader from '@components/Document/DocumentHeader';
+import markdownToHtml from '@utils/markdownToHtml';
 
 interface Props {
   params: {title: string; logId: string};
@@ -10,12 +11,13 @@ interface Props {
 const Page = async ({params}: Props) => {
   const {title, logId} = await params;
   const document = await getSpecificDocumentLog(Number(logId));
+  const contents = await markdownToHtml(document.contents);
 
   return (
     <section className="flex flex-col items-center w-full gap-6">
       <div className="flex flex-col gap-6 w-full h-fit bg-white border-primary-100 border-solid border rounded-xl p-8 max-[768px]:p-4 max-[768px]:gap-2 ">
         <DocumentHeader title={decodeURI(title)} />
-        <DocumentContents contents={document.contents} />
+        <DocumentContents contents={contents} />
       </div>
       <DocumentFooter generateTime={document.generateTime} />
     </section>


### PR DESCRIPTION
## issue

- close #15 

## 구현 사항
### 문서 조회 오류 페이지를 옮겨왔습니다.
![image](https://github.com/user-attachments/assets/578efbb5-8c84-4452-ab63-5b855fea047a)

Next.js app router에서는 에러 화면이 필요한 디렉터리에 error.tsx를 적용하면 커스텀 에러를 보여줄 수 있습니다.

아래 디렉터리 구조를 React에서 바라보면
- app
  - wiki
    - layout.tsx
    - page.tsx
    - loading.tsx
    - error.tsx

이렇게 변환할 수 있습니다.
```tsx
const Wiki = () => {
  <Layout>
    <ErrorBoundary FallbackComponent={<Error />}>
       <Suspense fallback={<Loading />}>
          <Page />
       </Suspense>
    </ErrorBoundary>
  </Layout>
}
```

error.tsx를 정의하면 react에서 바라볼 때 에러 바운더리의 fallback이 실행되는 것이라고 생각하면 되며 그렇기 때문에 error.tsx는 클라이언트 컴포넌트이어야합니다.  브라우저에서 서버로 요청을 실행한 뒤에 에러가 발생해서 에러 바운더리가 보여지는 흐름이기 때문입니다.


## 🫡 참고사항
### 편집로그 markdown -> html 적용하지 않아서 적용했습니다.

### 다음 이슈는 각 페이지 별 메타 태그 적용입니다.
