### PR TITLE
페이지 별 Meta tag 정의

### DIFF
--- a/client/src/app/wiki/[title]/edit/layout.tsx
+++ b/client/src/app/wiki/[title]/edit/layout.tsx
@@ -1,3 +1,16 @@
+import {TitleParams} from '@type/PageParams.type';
+import {Metadata} from 'next';
+
+export async function generateMetadata({params}: TitleParams): Promise<Metadata> {
+  const {title} = await params;
+  const documentTitle = decodeURI(title);
+
+  return {
+    title: `${documentTitle} 편집하기`,
+    description: `${documentTitle}의 새로운 정보(논란)를 공유해주세요!`,
+  };
+}
+
 const Layout = ({children}: React.PropsWithChildren) => {
   return (
     <section className="flex flex-col gap-6 w-full h-fit bg-white border-primary-100 border-solid border rounded-xl p-8 max-[768px]:p-4 max-[768px]:gap-3">

--- a/client/src/app/wiki/[title]/log/[logId]/page.tsx
+++ b/client/src/app/wiki/[title]/log/[logId]/page.tsx
@@ -2,13 +2,25 @@ import {getSpecificDocumentLog} from '@api/document';
 import DocumentContents from '@components/Document/DocumentContents';
 import DocumentFooter from '@components/Document/DocumentFooter';
 import DocumentHeader from '@components/Document/DocumentHeader';
+import type {LogParams} from '@type/PageParams.type';
 import markdownToHtml from '@utils/markdownToHtml';
+import {Metadata} from 'next';
 
-interface Props {
-  params: {title: string; logId: string};
+export async function generateMetadata({params}: LogParams): Promise<Metadata> {
+  const {title} = await params;
+  const documentTitle = decodeURI(title);
+
+  return {
+    title: documentTitle,
+    description: `${documentTitle}에 대한 정보(논란)를 확인하세요.`,
+    openGraph: {
+      title: `크루위키 ${documentTitle}의 문서`,
+      description: `${documentTitle}에 대한 정보(논란)를 확인하세요.`,
+    },
+  };
 }
 
-const Page = async ({params}: Props) => {
+const Page = async ({params}: LogParams) => {
   const {title, logId} = await params;
   const document = await getSpecificDocumentLog(Number(logId));
   const contents = await markdownToHtml(document.contents);

--- a/client/src/app/wiki/[title]/logs/page.tsx
+++ b/client/src/app/wiki/[title]/logs/page.tsx
@@ -1,11 +1,23 @@
+import type {TitleParams} from '@type/PageParams.type';
 import {LogContent} from './LogContent';
 import {getDocumentLogsByTitle} from '@api/document';
+import {Metadata} from 'next';
 
-interface Props {
-  params: {title: string};
+export async function generateMetadata({params}: TitleParams): Promise<Metadata> {
+  const {title} = await params;
+  const documentTitle = decodeURI(title);
+
+  return {
+    title: `${documentTitle} 편집로그`,
+    description: `${documentTitle} 문서의 편집로그입니다.`,
+    openGraph: {
+      title: `크루위키 ${documentTitle}문서의 편집로그`,
+      description: `${documentTitle}에 대한 정보(논란)를 확인하세요.`,
+    },
+  };
 }
 
-const Page = async ({params}: Props) => {
+const Page = async ({params}: TitleParams) => {
   const {title} = await params;
   const documentLogs = await getDocumentLogsByTitle(title);
 

--- a/client/src/app/wiki/[title]/page.tsx
+++ b/client/src/app/wiki/[title]/page.tsx
@@ -3,11 +3,9 @@ import DocumentContents from '@components/Document/DocumentContents';
 import DocumentFooter from '@components/Document/DocumentFooter';
 import DocumentHeader from '@components/Document/DocumentHeader';
 import {CACHE} from '@constants/cache';
+import type {TitleParams} from '@type/PageParams.type';
 import markdownToHtml from '@utils/markdownToHtml';
-
-interface Props {
-  params: {title: string};
-}
+import {Metadata} from 'next';
 
 export const revalidate = CACHE.time.revalidate;
 
@@ -19,9 +17,23 @@ export async function generateStaticParams() {
   return documents.map(({title}) => ({title}));
 }
 
+export async function generateMetadata({params}: TitleParams): Promise<Metadata> {
+  const {title} = await params;
+  const documentTitle = decodeURI(title);
+
+  return {
+    title: documentTitle,
+    description: `${documentTitle}에 대한 정보(논란)를 확인하세요.`,
+    openGraph: {
+      title: `크루위키 ${documentTitle}의 문서`,
+      description: `${documentTitle}에 대한 정보(논란)를 확인하세요.`,
+    },
+  };
+}
+
 // next.js v15부터 params를 받기 위해 await를 사용해야 함
 // https://nextjs.org/docs/messages/sync-dynamic-apis
-const DocumentPage = async ({params}: Props) => {
+const DocumentPage = async ({params}: TitleParams) => {
   const {title} = await params;
   const docs = await getDocumentByTitle(title);
 

--- a/client/src/app/wiki/post/layout.tsx
+++ b/client/src/app/wiki/post/layout.tsx
@@ -1,0 +1,12 @@
+import type {Metadata} from 'next';
+
+export const metadata: Metadata = {
+  title: '작성하기',
+  description: '크루들의 정보(논란)를 공유해주세요!',
+};
+
+const Layout = ({children}: React.PropsWithChildren) => {
+  return children;
+};
+
+export default Layout;

--- a/client/src/type/PageParams.type.ts
+++ b/client/src/type/PageParams.type.ts
@@ -1,0 +1,7 @@
+export type TitleParams = {
+  params: Promise<{title: string}>;
+};
+
+export type LogParams = {
+  params: Promise<{title: string; logId: string}>;
+};


### PR DESCRIPTION
## issue

- close #17 

## 구현하는 이유
next.js는 SPA가 아니기 때문에 페이지 별로 다른 html이 생성됩니다
그러므로 페이지 별로 Meta tag를 다르게 가져갈 수 있고, 이를 적용하려고 합니다.

이유는 문서를 작성하고 공유했을 때 풍부한 정보를 제공하기 위함입니다.
아래 사진처럼 특정 문서를 공유했는데 사이트 제목과 사이트 전체 설명만 보이면 와닿지 않기 때문입니다.

![Image](https://github.com/user-attachments/assets/195e4173-bdfd-4585-a616-315d953d277f)


## 구현 사항
### 페이지 별로 Title과 메타 태그 설정
각 페이지 성격에 맞는 Title과 description 그리고 메타태그를 설정했습니다.
서버 컴포넌트와 클라이언트 컴포넌트의 적용 방식이 조금 달라서 나누어 설명하겠습니다.
[next.js metadata](https://nextjs.org/docs/app/building-your-application/optimizing/metadata)를 참조하면서 설정했습니다.


#### Server Component (문서 확인, 편집로그 목록, 특정 편집로그 확인) title, 메타태그 설정
공식문서에 따르면 메타 데이터를 정적, 동적으로 생성할 수 있다고 나와 있습니다.
정적의 경우 페이지 params와 관계없이 동일한 메타태그를 넣고 싶을 때, 동적일 경우 페이지 params에 따라 다르게 설정하고 싶을 때 사용합니다.

크루위키의 경우 쿠키(6기) 문서를 조회하면 쿠키(6기)에 대한 정보를 메타태그로 설정하고 싶기 때문에 동적 방식을 선택했습니다.

동적 방식은 next.js에서 미리 정의해 둔 generateMetadata를 선언하면 됩니다.
[title] 디렉터리로 title 파라미터를 받아서 아래 return에 적절하게 활용하면 됩니다.
여기서 백엔드로 api를 호출하여 작성자, 문서 본문까지 가져올 수 있으나, 이런 정보까지 보여줄 필요는 없을 것 같아서 호출하지 않았습니다. (openGraph description에 작성자를 고민했지만 누가 작성했다는 정보를 대놓고 밝히는 것 같아서 적용하지 않았습니다.)

```tsx
export type TitleParams = {
  params: Promise<{title: string}>;
};

export async function generateMetadata({params}: TitleParams): Promise<Metadata> {
  const {title} = await params;
  const documentTitle = decodeURI(title);

  return {
    title: documentTitle,
    description: `${documentTitle}에 대한 정보(논란)를 확인하세요.`,
    openGraph: {
      title: `크루위키 ${documentTitle}의 문서`,
      description: `${documentTitle}에 대한 정보(논란)를 확인하세요.`,
    },
  };
}
```


### Client Component (문서 편집, 문서 작성) title, 메타태그 설정
공식문서에 따르면 'use client'로 선언된 컴포넌트(클라이언트 컴포넌트)에서는 정적, 동적 메타태그를 허용하지 않는다고 합니다. 하지만 이 페이지에서도 적절한 타이틀을 보여주는 것은 필요하다고 생각합니다.
그래서 page.tsx 상위에서 실행되는 layout.tsx를 활용했습니다. page.tsx가 클라이언트 컴포넌트 일지라도 그 상위에서 실행되는 layout.tsx는 서버 컴포넌트입니다. 그래서 layout에서 메타태그를 설정해주는 방식으로 구현했습니다.

문서 작성하기의 경우 동적으로 만들 필요가 없어서 정적 메타태그를 사용했습니다.
metadata 객체를 만들어서 export만 해주면 알아서 메타태그를 설정하게 됩니다.

```tsx
import type {Metadata} from 'next';

export const metadata: Metadata = {
  title: '작성하기',
  description: '크루들의 정보(논란)를 공유해주세요!',
};

const Layout = ({children}: React.PropsWithChildren) => {
  return children;
};

export default Layout;
```

### 개선 결과

#### 특정 문서 조회
<img width="960" alt="개선결과1" src="https://github.com/user-attachments/assets/f658c217-ddb5-420a-80d9-0db207c49a30" />

#### 특정 문서의 편집로그
<img width="960" alt="개선결과2" src="https://github.com/user-attachments/assets/c3bace1a-438f-4729-a0de-f5f852cbfeb1" />

#### 문서 작성하기
<img width="960" alt="개선결과3" src="https://github.com/user-attachments/assets/6248902f-5458-4347-a719-bbcf11f86d43" />

#### 특정 문서의 수정하기
<img width="960" alt="개선결과4" src="https://github.com/user-attachments/assets/070d338f-5b1f-43b1-bf3f-d948ae3322f1" />


## 논의하고 싶은 부분
### 메타태그 텍스트가 적절하게 설정됐는지 논의하고 싶어요.
### 동적 방식에서 openGraph description에 수정된 시간을 넣는 것은 어떨까요?


## 기대효과
슬랙, 카톡 등에 문서를 공유할 때, 특정 문서에 대한 정보가 보이게 되어 정보만 보고도 누구의 문서인지 확인 가능할 것이라 생각합니다.


## 🫡 참고사항
### 다음 이슈는 모바일 헤더 마이그레이션 입니다.
