### PR TITLE
ISR, SSG에 대한 생각과, revalidate 시간 설정

### DIFF
--- a/client/src/apis/document.ts
+++ b/client/src/apis/document.ts
@@ -8,7 +8,7 @@ import {requestGet} from '@apis/http';
 export const getDocumentByTitle = async (title: string) => {
   const docs = await requestGet<WikiDocument>({
     endpoint: `${ENDPOINT.getDocumentByTitle}/${title}`,
-    next: {revalidate: CACHE.time.revalidate, tags: [CACHE.tag.getDocumentByTitle(title)]},
+    next: {revalidate: CACHE.time.basicRevalidate, tags: [CACHE.tag.getDocumentByTitle(title)]},
   });
 
   return docs;
@@ -17,7 +17,7 @@ export const getDocumentByTitle = async (title: string) => {
 export const getDocumentLogsByTitle = async (title: string) => {
   const logs = await requestGet<WikiDocumentLogSummary[]>({
     endpoint: ENDPOINT.getDocumentLogsByTitle(title),
-    next: {revalidate: CACHE.time.revalidate, tags: [CACHE.tag.getDocumentLogsByTitle(title)]},
+    next: {revalidate: CACHE.time.basicRevalidate, tags: [CACHE.tag.getDocumentLogsByTitle(title)]},
   });
 
   return logs.sort((a: WikiDocumentLogSummary, b: WikiDocumentLogSummary) =>
@@ -28,7 +28,7 @@ export const getDocumentLogsByTitle = async (title: string) => {
 export const getSpecificDocumentLog = async (logId: number) => {
   const response = await requestGet<WikiDocumentLogDetail>({
     endpoint: ENDPOINT.getSpecificDocumentLog(logId),
-    next: {revalidate: CACHE.time.revalidate, tags: [CACHE.tag.getSpecificDocumentLog(logId)]},
+    next: {revalidate: CACHE.time.longRevalidate, tags: [CACHE.tag.getSpecificDocumentLog(logId)]},
   });
 
   return response;
@@ -37,7 +37,7 @@ export const getSpecificDocumentLog = async (logId: number) => {
 export const getRandomDocument = async () => {
   const docs = await requestGet<WikiDocument>({
     endpoint: ENDPOINT.getRandomDocument,
-    next: {revalidate: CACHE.time.revalidate, tags: [CACHE.tag.getRandomDocument]},
+    cache: 'no-cache',
   });
 
   return docs.title;
@@ -50,7 +50,7 @@ interface RecentlyDocumentsResponse {
 export const getRecentlyDocuments = async () => {
   const {documents} = await requestGet<RecentlyDocumentsResponse>({
     endpoint: ENDPOINT.getRecentlyDocuments,
-    next: {revalidate: CACHE.time.revalidate, tags: [CACHE.tag.getRecentlyDocuments]},
+    next: {revalidate: CACHE.time.basicRevalidate, tags: [CACHE.tag.getRecentlyDocuments]},
   });
 
   return documents;

--- a/client/src/apis/document.ts
+++ b/client/src/apis/document.ts
@@ -67,6 +67,7 @@ export interface PostDocumentContent {
 export const searchDocument = async (referQuery: string) => {
   const titles = await requestGet<string[]>({
     endpoint: ENDPOINT.getDocumentSearch,
+    cache: 'no-cache',
     queryParams: {
       keyWord: referQuery,
     },

--- a/client/src/constants/cache.ts
+++ b/client/src/constants/cache.ts
@@ -1,7 +1,9 @@
-// ISR : cache 시간 어떻게 가져갈 지 논의 (안 가져가는 것도 좋을 듯)
+// ISR : cache 시간 어떻게 가져갈 지 논의
+// revalidate 1s
 export const CACHE = {
   time: {
-    revalidate: 30,
+    basicRevalidate: 43200, // 12 hours
+    longRevalidate: 604800, // 7 days
   },
   tag: {
     getDocuments: 'documents',


### PR DESCRIPTION
## issue

- close #23 

## 크루위키의 렌더링 전략

### 크루위키의 정적 페이지 분석

#### 1. 문서 확인
<img src="https://github.com/user-attachments/assets/77de299a-141f-403b-995a-63cdba9a5840" width="500" />

&nbsp;

크루위키 사용자들의 **방문율이 높은 페이지**입니다. 크루위키를 처음 실행했을 때 보이는 대문 페이지도 이 페이지 형식이며 각 문서의 최신 상태를 확인할 수 있습니다. 문서 수정이 일어나면 수정된 정보가 바로 적용이 되어야 합니다.

#### 2. 문서 편집로그 확인
<img src="https://github.com/user-attachments/assets/9700964f-512c-4344-ab73-865668e8092b" width="500" />

&nbsp;

크루위키 사용자들의 방문율이 높지 않을 것이라 예상합니다. (정확한 수치는 트래킹 코드를 삽입하여 비율을 확인해 볼 예정입니다.) 각 문서의 변경 로그를 확인할 수 있는 페이지이며 **문서 수정이 일어나면 새로운 로그가 위에 보이게** 됩니다.


#### 3. 문서 특정 편집로그 확인
<img src="https://github.com/user-attachments/assets/7deef6f1-83b5-44ac-b4d9-7306cd51df6f" width="500" />

&nbsp;

이 페이지 또한 크루위키 사용자들의 방문율이 높지 않을 것이라 예상합니다. (정확한 수치는 트래킹 코드를 삽입하여 비율을 확인해 볼 예정입니다.) 각 문서의 특정 로그를 확인할 수 있는 페이지이며, 이 페이지는 **새로운 로그가 아닌 이상 절대로 바뀔 수 없습니다.**


### 페이지 별 적용한 렌더링 전략

정적 페이지 3가지 전부 **ISR 방식을 적용**했습니다. 실시간 성이 아닌 위키 특성 상 요청 시 매번 html을 만들어서 응답하는 것보다 미리 만들어둔 html을 반환하는 것이 더 효과적이라고 생각했습니다. 그러면 SSG를 선택하는 것이 맞지 않을까 생각할 수 있지만 SSG는 사용자 변경 요청 시 새로운 데이터를 불러올 수 없어서 ISR을 선택하게 되었습니다. 


#### 1. 문서 확인 : ISR + generateStaticParams (SSG와 유사)

1) 사용자 측면에서
문서 확인 페이지는 사용자들이 가장 많이 사용하는 페이지입니다. 그러므로 **빠른 응답과 최신성이 보장**되어야 합니다.
사용자가 페이지를 요청할 때 서버에서 페이지를 제작한 후 보내주는 것보다, **사전 빌드 시점에 미리 만들어둔 html을 요청할 때 응답한다면 더 빠른 응답**을 할 수 있을 것 같아 generateStaticParams를 설정하게 되었습니다. 

revalidate 시간은 12시간으로 설정했습니다. 여기서 revalidate를 길게 가져간다고 했을 때 최신성을 보장하지 못할 수 있지 않을까 하는 우려가 있을 수 있는데 최신성은 문서가 변경됐을 때 **on demand revalidate기법**을 사용하여(revalidateTag) 서버의 캐시를 무효화하고 그 다음 요청부터 최신화한 html 응답 및 서버 캐시에 저장하게 되어, 최신성을 보장 받을 수 있습니다.

(브라우저의 캐시가 아니라 **서버의 캐시이기 때문에 변경된 다음 요청부터 모두가 최신 응답**을 받을 수 있게 됩니다.)


2) 크롤러 입장에서
웹 크롤러 입장에서 크루위키를 검색했을 때 서버에서 html을 만든 뒤에 보여주는 것보다 미리 만들어둔 html을 바로 보이게 한다면 **SEO 측면에서 더 좋은 점수**를 얻을 수 있으며, 각 문서 별로 다른 메타태그를 설정하여 크롤러에게 더 알맞은 정보를 줄 수 있다고 생각하여 generateStaticParams를 사용하여 빌드 시에 서버에 문서를 만들어뒀습니다.

**=> 정리: 문서 확인 페이지는 ISR + generateStaticParams로 서버 빌드 시 페이지 생성, revalidate 12시간**


#### 2. 문서 편집로그 확인 : ISR

1) 사용자 입장에서 
문서 편집로그 확인 페이지는 사용자가 그렇게 많이 확인하지 않을 것 같은 페이지입니다. 편집로그 버튼을 타고 들어가는 1depth가 있기 때문입니다. (이것도 정확히 수치로 보고 싶어요... 문서의 역사를 보고 싶은 사람이 얼마나 많을까 궁금하네요) 그래서 **사전 빌드 단계에서 페이지 목록을 가지고 있을 필요가 없다고 생각**하여 generateStaticParams를 적용하지 않았습니다. 또한 이 페이지는 문서 수정 시 새로운 로그가 위에 보여야 하므로 어느 정도의 최신성을 챙겨야 합니다. 그래서 revalidate 시간을 위와 동일하게 12시간으로 설정했습니다.

2) 크롤러 입장에서
굳이 문서 편집로그까지 좋은 평가를 받아야 할 지 모르겠습니다. 사람들이 문서의 역사에 대해 관심이 많고 이 페이지를 정말 많이 접속한다면 generateStaticParams를 고려해봐도 좋을 것 같습니다. (아마 그럴 일 없을 듯ㅋㅋ)


**=> 정리: 문서 편집로그 페이지는 ISR로 revalidate 12시간**


#### 3. 문서 특정 편집로그 확인 : ISR

1) 사용자 입장에서 
문서 특정 편집로그 확인 페이지는 편집로그 목록보다 더 많이 확인하지 않을 것 같은 페이지입니다. 이 페이지에 진입하기 위해서 2depth가 필요하기 때문입니다. 그래서 이 역시 사전 빌드 단계에서 페이지 목록을 가지고 있을 필요가 없다고 생각하여 generateStaticParams를 적용하지 않았습니다. **이 페이지는 수정될 일이 없습니다**. 새로운 로그 페이지가 생성되는 것 이외에 변경될 여지가 없습니다. 그래서 **revalidate 시간을 위와는 다르게 7일**로 설정했습니다.

그렇다면 여기서 내용이 전혀 바뀌지 않으니 SSG를 사용해서 무조건 정적인 응답만 하면 되는 것 아닌가 하는 의문이 들 수 있습니다. 하지만 저는 **사전 빌드 시점에서 정적 파일 생성에 대한 비용**을 걱정했습니다.

지금 현재 문서는 약 130개이며 그 안의 각각 편집 로그가 있어 약 **1200개의 데이터**가 저장되어있습니다. 이 데이터를 사전 빌드 할 때 전부 데이터를 불러와서 정적 파일로 만들어두게 됩니다. 크루위키를 유지보수 하지 않는다면 1200개라도 초기에 불러와서 저장해두는 것이 좋을 것이지만, 유지보수가 이루어지고 주기적으로 코드가 빌드된다면 **매 번 빌드 할 때마다 현재 페이지 130개, 로그 페이지 1200개 데이터를 백엔드로 요청**하게 되는 것입니다.

이 이유로 중요하지 않으며, 사용자가 확인할 지도 모르는 페이지를 빌드할 때마다 부담이 되게 하고 싶지 않아서 ISR 방식을 적용했습니다.


2) 크롤러 입장에서
편집로그 목록과 동일하게 문서 특정 편집로그까지 좋은 평가를 받아야 할 지 모르겠습니다.


**=> 정리: 문서 특정 편집로그 페이지는 ISR로 revalidate 7일**


## 기타 GET 요청에 대한 revalidate 적용
- 문서 최근 편집 목록 : revalidate 12시간
- 문서 검색 : no-cache -> 요청할 때마다 응답을 받아야 하기 때문
- 문서 랜덤조회: no-cache -> 요청할 때마다 다른 응답을 받아야 하기 때문


## 🫡 참고사항
