### PR TITLE
랜덤 아이콘 크기가 변동되는 현상 해결

### DIFF
--- a/client/src/components/common/RandomButton/useRandomButton.ts
+++ b/client/src/components/common/RandomButton/useRandomButton.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import {getRandomDocument} from '@apis/document';
 import {URLS} from '@constants/urls';
 import {useRouter} from 'next/navigation';
@@ -11,7 +13,7 @@ export const useRandomButton = () => {
     router.push(`${URLS.wiki}/${randomTitle}`);
   };
 
-  const [isMobile, setIsMobile] = useState(false);
+  const [isMobile, setIsMobile] = useState<boolean>(window.innerWidth <= 768);
 
   useEffect(function addEventListenerForDetectWindowSize() {
     const handleResize = () => {

--- a/client/src/components/layout/Header/RightHeader.tsx
+++ b/client/src/components/layout/Header/RightHeader.tsx
@@ -1,0 +1,21 @@
+import RandomButton from '@components/common/RandomButton';
+import WikiInputField from './WikiInputField';
+import Image from 'next/image';
+import SearchCircleSmall from '@app/image/search-circle.svg';
+
+type RightHeaderProps = {
+  onSubmit: () => void;
+  toggleVisibility: () => void;
+};
+
+const RightHeader = ({onSubmit, toggleVisibility}: RightHeaderProps) => {
+  return (
+    <div className="flex items-center">
+      <RandomButton />
+      <WikiInputField className="w-80 hidden md:flex" handleSubmit={onSubmit} />
+      <Image src={SearchCircleSmall} alt="search" className="cursor-pointer md:hidden" onClick={toggleVisibility} />
+    </div>
+  );
+};
+
+export default RightHeader;

--- a/client/src/components/layout/Header/WikiHeader.tsx
+++ b/client/src/components/layout/Header/WikiHeader.tsx
@@ -4,11 +4,12 @@ import Link from 'next/link';
 import Image from 'next/image';
 import {useState, useEffect} from 'react';
 import {motion} from 'framer-motion';
-import SearchCircleSmall from '@app/image/search-circle.svg';
 import LogoImage from '@app/image/hangseong-white.png';
 import {twMerge} from 'tailwind-merge';
 import WikiInputField from './WikiInputField';
-import RandomButton from '@components/common/RandomButton';
+
+import dynamic from 'next/dynamic';
+const RightHeader = dynamic(() => import('./RightHeader'), {ssr: false});
 
 interface ScrollPosition {
   prev: number;
@@ -68,16 +69,7 @@ const WikiHeader = () => {
             <h1 className="font-bm text-2xl md:text-[40px] text-white font-normal">크루위키</h1>
           </Link>
 
-          <div className="flex items-center">
-            <RandomButton />
-            <WikiInputField className="w-80 hidden md:flex" handleSubmit={onSubmit} />
-            <Image
-              src={SearchCircleSmall}
-              alt="search"
-              className="cursor-pointer md:hidden"
-              onClick={toggleVisibility}
-            />
-          </div>
+          <RightHeader onSubmit={onSubmit} toggleVisibility={toggleVisibility} />
         </div>
         <div
           className={twMerge(


### PR DESCRIPTION
## issue

- close #29 

## 구현 사항
### dynamic import를 사용해서 헤더의 우측을 클라이언트에서 실행되도록 보장
서버의 시점에서 봤을 때 어떤 브라우저에서 요청이 올지 (모바일, 데스크탑) 파악할 수 없습니다. 그래서 초기 값을 임의로 설정했다가 일어난 이슈입니다.

그래서 헤더의 우측 부분을 클라이언트에서 실행되도록 dynamic import를 사용했습니다.

```tsx
import dynamic from 'next/dynamic';
const RightHeader = dynamic(() => import('./RightHeader'), {ssr: false});
```

이렇게 한다면 RightHeader 컴포넌트는 서버에서 실행되지 않고 반드시 클라이언트에서 실행되고 초기값으로 window를 사용할 수 있습니다. 

```ts
const [isMobile, setIsMobile] = useState<boolean>(window.innerWidth <= 768);
```


### 개선결과


https://github.com/user-attachments/assets/35cb6310-9687-46d0-8008-10443d008f64



## 논의하고 싶은 부분

아이콘 크기는 일정해졌지만 새로고침 시 랜덤 아이콘과 검색 창 전부 깜빡이는 현상이 일어납니다.
이건 선택인 것 같아요.

랜덤 아이콘이 일시적으로 커졌다가 작아지기 vs 전체적으로 깜빡이기

어떤 것이 더 좋지 않은 경험을 주는지 테스트 해보고 싶습니다



## 🫡 참고사항
