### PR TITLE
문서 수정이 보이지 않는 문제

### DIFF
--- a/client/src/components/document/TuiEditor/useRelativeSearchTerms.ts
+++ b/client/src/components/document/TuiEditor/useRelativeSearchTerms.ts
@@ -14,7 +14,7 @@ export const useRelativeSearchTerms = ({editorRef}: UseRelativeSearchTermArgs) =
   const [refEndPos, setRefEndPos] = useState<[number, number] | null>(null);
   const [floatingAreaPosition, setFloatingAreaPosition] = useState<{top: number; left: number}>({top: 0, left: 0});
 
-  const {titles} = useSearchDocumentByQuery(referQuery);
+  const {titles} = useSearchDocumentByQuery(referQuery, {enabled: false});
   const floatingArea = typeof document !== 'undefined' ? document.createElement('div') : null;
 
   if (floatingArea) {

--- a/client/src/components/document/Write/TitleInputField.tsx
+++ b/client/src/components/document/Write/TitleInputField.tsx
@@ -13,7 +13,7 @@ const TitleInputField = ({disabled = false}: TitleInputField) => {
   const {title, onTitleChange, onTitleBlur, titleErrorMessage} = titleProps;
   const {writer, onWriterChange, writerErrorMessage} = writerProps;
 
-  const {titles} = useSearchDocumentByQuery('', {enabled: true});
+  const {titles} = useSearchDocumentByQuery('');
 
   return (
     <div className="flex flex-col gap-2 w-full">

--- a/client/src/components/layout/Header/WikiInputField.tsx
+++ b/client/src/components/layout/Header/WikiInputField.tsx
@@ -18,7 +18,7 @@ const WikiInputField = ({className, handleSubmit}: WikiInputProps) => {
   const {value, directlyChangeValue: setValue, onChange} = useInput({});
   const router = useRouter();
 
-  const {titles} = useSearchDocumentByQuery(value);
+  const {titles} = useSearchDocumentByQuery(value, {enabled: false});
 
   const onSubmit = (event: React.FormEvent) => {
     event.preventDefault();

--- a/client/src/hooks/useFetch.ts
+++ b/client/src/hooks/useFetch.ts
@@ -6,7 +6,7 @@ type UseFetchOptions = {
   enabled?: boolean;
 };
 
-export const useFetch = <T>(fetchFunction: () => Promise<T>, options?: UseFetchOptions) => {
+export const useFetch = <T>(fetchFunction: () => Promise<T>, options: UseFetchOptions = {enabled: true}) => {
   const [data, setData] = useState<T | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -27,7 +27,7 @@ export const useFetch = <T>(fetchFunction: () => Promise<T>, options?: UseFetchO
   }, [fetchFunction]);
 
   useEffect(() => {
-    if (options?.enabled === true) {
+    if (options?.enabled) {
       fetchData();
     }
   }, [fetchData, fetchFunction, options?.enabled]);


### PR DESCRIPTION
## issue

- close #31 

## 구현 사항
### useFetch options의 enabled 기본 값을 true로 설정
수정 페이지 접속 시 문서 정보를 호출해야 하는데, enabled 초기 값이 없어서 요청이 가지 않는 문제였습니다.
아래처럼 수정해서 enabled를 명시적으로 주지 않으면 자동으로 fetch 해오도록 수정했습니다.

```ts
export const useFetch = <T>(fetchFunction: () => Promise<T>, options: UseFetchOptions = {enabled: true}) => {
  ...
  useEffect(() => {
      if (options?.enabled) {
        fetchData();
      }
    }, [fetchData, fetchFunction, options?.enabled]);
}
```


## 🫡 참고사항
