### PR TITLE
문서 작성하기 초기 템플릿 설정

### DIFF
--- a/client/src/app/wiki/[title]/edit/page.tsx
+++ b/client/src/app/wiki/[title]/edit/page.tsx
@@ -14,7 +14,7 @@ const EditPage = () => {
     <>
       <PostHeader />
       <TitleInputField disabled />
-      <TuiEditor initialValue={contentsProps.initialContents ?? null} />
+      <TuiEditor initialValue={contentsProps.initialContents} />
     </>
   );
 };

--- a/client/src/app/wiki/post/usePostSaveMarkdown.ts
+++ b/client/src/app/wiki/post/usePostSaveMarkdown.ts
@@ -1,5 +1,6 @@
 'use client';
 
+import {EDITOR} from '@constants/editor';
 import KEYS from '@constants/keys';
 import {mySessionStorage} from '@utils/mySessionStorage';
 import {useCallback} from 'react';
@@ -14,7 +15,7 @@ export const usePostSaveMarkdown = () => {
   const initialValue =
     typeof window !== 'undefined' && mySessionStorage.has([KEYS.SESSION_STORAGE.post])
       ? (mySessionStorage.get([KEYS.SESSION_STORAGE.post]) as string)
-      : null;
+      : EDITOR.initialValue;
 
   return {saveMarkdown, initialValue};
 };

--- a/client/src/components/document/TuiEditor/index.tsx
+++ b/client/src/components/document/TuiEditor/index.tsx
@@ -24,7 +24,7 @@ const toolbar = [
 
 type TuiEditorProps = {
   saveMarkdown?: (markdown: string) => void;
-  initialValue: string | null;
+  initialValue: string;
 };
 
 function TuiEditor({initialValue, saveMarkdown}: TuiEditorProps) {
@@ -91,7 +91,7 @@ function TuiEditor({initialValue, saveMarkdown}: TuiEditorProps) {
     <div onClick={onClick}>
       <DynamicLoadEditor
         ref={editorRef}
-        initialValue={'내용을 입력해주세요.'}
+        initialValue={initialValue}
         onChange={handleChange}
         initialEditType="markdown"
         autofocus={false}

--- a/client/src/constants/editor.ts
+++ b/client/src/constants/editor.ts
@@ -1,0 +1,21 @@
+export const EDITOR = {
+  initialValue: `# 프로필
+<table>
+  <tr>
+    <th>닉네임</th>
+    <td></td>
+  </tr>
+  <tr>
+    <th>생일</th>
+    <td></td>
+  </tr>
+  <tr>
+    <th>소속/기수</th>
+    <td></td>
+  </tr>
+  <tr>
+    <th>MBTI</th>
+    <td></td>
+  </tr>
+</table>`,
+} as const;

--- a/client/src/context/DocumentWriteContext.tsx
+++ b/client/src/context/DocumentWriteContext.tsx
@@ -13,6 +13,7 @@ import {uploadImages} from '@apis/images';
 import {usePostDocument} from '@hooks/mutation/usePostDocument';
 import {usePutDocument} from '@hooks/mutation/usePutDocument';
 import {replaceLocalUrlToS3Url} from '@utils/replaceLocalUrlToS3Url';
+import {EDITOR} from '@constants/editor';
 
 export type TitleProps = {
   title: string;
@@ -29,7 +30,7 @@ export type WriterProps = {
 
 export type ContentsProps = {
   contents: string;
-  initialContents?: string;
+  initialContents: string;
   onContentsChange: (value: string) => void;
   setImages: React.Dispatch<React.SetStateAction<UploadImageMeta[]>>;
 };
@@ -86,8 +87,8 @@ export const DocumentWriteContextProvider = ({children, mode, ...initialData}: D
   const editorRef = useRef<EditorType | null>(null);
   const [images, setImages] = useState<UploadImageMeta[]>([]);
 
-  const initialContents = initialData.contents;
-  const [contents, setContents] = useState(initialContents ?? '');
+  const initialContents = initialData.contents ?? EDITOR.initialValue;
+  const [contents, setContents] = useState(initialContents);
 
   const onContentsChange = useCallback((value: string) => {
     setContents(value);


### PR DESCRIPTION
## issue

- close #33 

## 구현 사항
### 문서 작성 시 프로필 테이블을 보여주어, 프로필을 적도록 유도

![image](https://github.com/user-attachments/assets/799d0752-bc07-4f80-881e-9211f535ac8b)

새로운 문서를 작성할 때 닉네임, 생일, 소속/기수, MBTI를 적을 수 있도록 유도했습니다.


## 🫡 참고사항
