### PR TITLE
자동 완성 검색 최상단 밖에 클릭이 되지 않는 버그

### DIFF
--- a/client/src/components/common/SearchTerms/RelativeSearchTerms.tsx
+++ b/client/src/components/common/SearchTerms/RelativeSearchTerms.tsx
@@ -4,15 +4,22 @@ interface RelativeSearchTermsProps {
   style?: React.CSSProperties;
   show?: boolean;
   searchTerms: string[];
+  onClick?: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
 }
 
-const RelativeSearchTerms = ({style, searchTerms, show = searchTerms.length > 0}: RelativeSearchTermsProps) => {
+const RelativeSearchTerms = ({
+  style,
+  searchTerms,
+  show = searchTerms.length > 0,
+  onClick,
+}: RelativeSearchTermsProps) => {
   return (
     show && (
       <aside style={style} className="absolute rounded-xl shadow-2xl px-2 py-2 left-0 top-12 w-full bg-white">
         {searchTerms.map((search, index) => (
           <button
             id={search}
+            onClick={onClick}
             className="w-full px-2 py-2 hover:bg-primary-50 rounded-lg cursor-pointer text-left font-pretendard text-base font-normal text-grayscale-800"
             key={index}
           >

--- a/client/src/components/layout/Header/WikiInputField.tsx
+++ b/client/src/components/layout/Header/WikiInputField.tsx
@@ -8,6 +8,7 @@ import Image from 'next/image';
 import {useRouter} from 'next/navigation';
 import useSearchDocumentByQuery from '@hooks/fetch/useSearchDocumentByQuery';
 import RelativeSearchTerms from '@components/common/SearchTerms/RelativeSearchTerms';
+import {useRef} from 'react';
 
 interface WikiInputProps {
   className?: string;
@@ -20,13 +21,16 @@ const WikiInputField = ({className, handleSubmit}: WikiInputProps) => {
 
   const {titles} = useSearchDocumentByQuery(value, {enabled: false});
 
+  const formRef = useRef<HTMLFormElement>(null);
+
   const onSubmit = (event: React.FormEvent) => {
     event.preventDefault();
-    const targetTitle = (event.target as HTMLElement).closest('button')?.id;
-
     if (value?.trim() === '') return;
 
-    if (targetTitle !== undefined) {
+    const submitter = (event.nativeEvent as SubmitEvent).submitter;
+    const targetTitle = submitter?.id;
+
+    if (targetTitle !== 'search-icon') {
       router.push(`${URLS.wiki}/${targetTitle}`);
     } else if (titles !== undefined && titles.length !== 0) {
       router.push(`${URLS.wiki}/${titles[0]}`);
@@ -38,8 +42,15 @@ const WikiInputField = ({className, handleSubmit}: WikiInputProps) => {
     handleSubmit();
   };
 
+  const onClick = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+    if (formRef.current) {
+      formRef.current.requestSubmit(event.target as HTMLElement);
+    }
+  };
+
   return (
     <form
+      ref={formRef}
       onSubmit={onSubmit}
       className={twMerge(
         'flex relative h-11 px-4 py-2.5 rounded-xl bg-white border-grayscale-200 border-solid border gap-2',
@@ -53,10 +64,10 @@ const WikiInputField = ({className, handleSubmit}: WikiInputProps) => {
         value={value}
         onChange={onChange}
       />
-      <button type="submit">
+      <button type="submit" id="search-icon">
         <Image className="cursor-pointer max-[768px]:hidden" src={SearchCircle} alt="search" />
       </button>
-      {value.trim() !== '' && <RelativeSearchTerms searchTerms={titles ?? []} />}
+      {value.trim() !== '' && <RelativeSearchTerms onClick={onClick} searchTerms={titles ?? []} />}
     </form>
   );
 };

--- a/client/src/components/layout/Header/WikiInputField.tsx
+++ b/client/src/components/layout/Header/WikiInputField.tsx
@@ -8,7 +8,6 @@ import Image from 'next/image';
 import {useRouter} from 'next/navigation';
 import useSearchDocumentByQuery from '@hooks/fetch/useSearchDocumentByQuery';
 import RelativeSearchTerms from '@components/common/SearchTerms/RelativeSearchTerms';
-import {useRef} from 'react';
 
 interface WikiInputProps {
   className?: string;
@@ -20,8 +19,6 @@ const WikiInputField = ({className, handleSubmit}: WikiInputProps) => {
   const router = useRouter();
 
   const {titles} = useSearchDocumentByQuery(value, {enabled: false});
-
-  const formRef = useRef<HTMLFormElement>(null);
 
   const onSubmit = (event: React.FormEvent) => {
     event.preventDefault();
@@ -44,7 +41,6 @@ const WikiInputField = ({className, handleSubmit}: WikiInputProps) => {
 
   return (
     <form
-      ref={formRef}
       onSubmit={onSubmit}
       className={twMerge(
         'flex relative h-11 px-4 py-2.5 rounded-xl bg-white border-grayscale-200 border-solid border gap-2',

--- a/client/src/components/layout/Header/WikiInputField.tsx
+++ b/client/src/components/layout/Header/WikiInputField.tsx
@@ -42,12 +42,6 @@ const WikiInputField = ({className, handleSubmit}: WikiInputProps) => {
     handleSubmit();
   };
 
-  const onClick = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
-    if (formRef.current) {
-      formRef.current.requestSubmit(event.target as HTMLElement);
-    }
-  };
-
   return (
     <form
       ref={formRef}
@@ -67,7 +61,7 @@ const WikiInputField = ({className, handleSubmit}: WikiInputProps) => {
       <button type="submit" id="search-icon">
         <Image className="cursor-pointer max-[768px]:hidden" src={SearchCircle} alt="search" />
       </button>
-      {value.trim() !== '' && <RelativeSearchTerms onClick={onClick} searchTerms={titles ?? []} />}
+      {value.trim() !== '' && <RelativeSearchTerms searchTerms={titles ?? []} />}
     </form>
   );
 };


### PR DESCRIPTION
## issue

- close #35 

## 구현 사항
### form tag 내에서 closest 사용 문제
@언급 쪽에서는 form 태그가 없어서 해당 버튼을 클릭했을 때 그 버튼의 id값을 무사히 가져올 수 있었는데, form 태그 내부에서 onSubmit이 될 event target를 사용하면 form 태그 그 자체가 타겟이 되어버려서 값을 가져올 수 없는 상황이었습니다.


### submit 이벤트의 submitter 찾아오기
우리의 목표는 submit이 될 때 해당 버튼의 id를 가져오는 것이므로, submit이 일어날 때 submit을 발생 시킨 버튼을 찾아오면 됩니다. submit 이벤트 안에 submit을 발생시킨 submitter를 가져올 수 있고 이를 활용하면 버튼의 id를 가져올 수 있게 됩니다.

```tsx
const submitter = (event.nativeEvent as SubmitEvent).submitter;
const targetTitle = submitter?.id;
```

하지만 여기서 검색 아이콘도 포함되어있어, 이 버튼을 누를 때 예외처리를 해줬습니다.

```tsx
if (targetTitle !== 'search-icon') {
  router.push(`${URLS.wiki}/${targetTitle}`);
} else if (titles !== undefined && titles.length !== 0) {
  router.push(`${URLS.wiki}/${titles[0]}`);
} else {
  router.push(`${URLS.wiki}/${value}`);
}
```


## 🫡 참고사항
