### PR TITLE
Amplitude 연결 및 사용자 트래킹 코드 작성

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@amplitude/analytics-browser": "^2.11.11",
     "@toast-ui/react-editor": "^3.2.3",
     "aws-sdk": "^2.1692.0",
     "dayjs": "^1.11.13",

--- a/client/src/app/wiki/layout.tsx
+++ b/client/src/app/wiki/layout.tsx
@@ -1,9 +1,11 @@
+import {AmplitudeInitializer} from '@components/common/AmplitudeInitializer';
 import WikiHeader from '@components/layout/Header/WikiHeader';
 import RecentlyEdit from '@components/layout/RecentlyEdit';
 
 const Layout = ({children}: React.PropsWithChildren) => {
   return (
     <div className="App relative">
+      <AmplitudeInitializer />
       <WikiHeader />
       <main className="flex items-start justify-center h-fit gap-6 py-6 px-4 max-w-[1440px] w-full max-[768px]:py-2 max-[768px]:px-0">
         {children}

--- a/client/src/components/common/AmplitudeInitializer/index.tsx
+++ b/client/src/components/common/AmplitudeInitializer/index.tsx
@@ -5,7 +5,14 @@ import {init} from '@amplitude/analytics-browser';
 
 export const AmplitudeInitializer = () => {
   useEffect(() => {
-    init(process.env.NEXT_PUBLIC_AMPLITUDE_API_KEY);
+    init(process.env.NEXT_PUBLIC_AMPLITUDE_API_KEY, {
+      autocapture: {
+        elementInteractions: false,
+        fileDownloads: false,
+        sessions: false,
+        formInteractions: false,
+      },
+    });
   }, []);
 
   return null;

--- a/client/src/components/common/AmplitudeInitializer/index.tsx
+++ b/client/src/components/common/AmplitudeInitializer/index.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import {useEffect} from 'react';
+import {init} from '@amplitude/analytics-browser';
+
+export const AmplitudeInitializer = () => {
+  useEffect(() => {
+    init(process.env.NEXT_PUBLIC_AMPLITUDE_API_KEY);
+  }, []);
+
+  return null;
+};

--- a/client/src/hooks/mutation/usePostDocument.ts
+++ b/client/src/hooks/mutation/usePostDocument.ts
@@ -6,9 +6,11 @@ import useMutation from '@hooks/useMutation';
 import {WikiDocument} from '@type/Document.type';
 import {requestPost} from '@apis/http';
 import {useRouter} from 'next/navigation';
+import useAmplitude from '@hooks/useAmplitude';
 
 export const usePostDocument = () => {
   const router = useRouter();
+  const {trackDocumentCreate} = useAmplitude();
 
   const postDocument = async (document: PostDocumentContent) => {
     const newDocument = await requestPost<WikiDocument>({
@@ -23,6 +25,7 @@ export const usePostDocument = () => {
   const {mutate, isPending} = useMutation<PostDocumentContent, WikiDocument>({
     mutationFn: postDocument,
     onSuccess: document => {
+      trackDocumentCreate(document.title);
       router.push(`${URLS.wiki}/${document.title}`);
     },
   });

--- a/client/src/hooks/mutation/usePutDocument.ts
+++ b/client/src/hooks/mutation/usePutDocument.ts
@@ -6,9 +6,11 @@ import useMutation from '@hooks/useMutation';
 import {WikiDocument} from '@type/Document.type';
 import {requestPut} from '@apis/http';
 import {useRouter} from 'next/navigation';
+import useAmplitude from '@hooks/useAmplitude';
 
 export const usePutDocument = () => {
   const router = useRouter();
+  const {trackDocumentUpdate} = useAmplitude();
 
   const putDocument = async (document: PostDocumentContent) => {
     const editDocument = await requestPut<WikiDocument>({
@@ -23,6 +25,7 @@ export const usePutDocument = () => {
   const {mutate, isPending} = useMutation<PostDocumentContent, WikiDocument>({
     mutationFn: putDocument,
     onSuccess: document => {
+      trackDocumentUpdate(document.title);
       router.push(`${URLS.wiki}/${document.title}`);
       router.refresh();
     },

--- a/client/src/hooks/useAmplitude.ts
+++ b/client/src/hooks/useAmplitude.ts
@@ -1,0 +1,40 @@
+'use client';
+
+import {track} from '@amplitude/analytics-browser';
+import {useCallback} from 'react';
+
+const useAmplitude = () => {
+  const trackEvent = useCallback((eventName: string, eventProps: Record<string, unknown> = {}) => {
+    const domainEnv = process.env.NODE_ENV;
+
+    track({
+      event_type: eventName,
+      event_properties: {domain: domainEnv, ...eventProps},
+    });
+  }, []);
+
+  const trackDocumentCreate = useCallback(
+    (title: string) => {
+      trackEvent('문서 작성', {
+        title,
+      });
+    },
+    [trackEvent],
+  );
+
+  const trackDocumentUpdate = useCallback(
+    (title: string) => {
+      trackEvent('문서 수정', {
+        title,
+      });
+    },
+    [trackEvent],
+  );
+
+  return {
+    trackDocumentCreate,
+    trackDocumentUpdate,
+  };
+};
+
+export default useAmplitude;

--- a/client/src/import-env.d.ts
+++ b/client/src/import-env.d.ts
@@ -6,6 +6,6 @@ declare namespace NodeJS {
     NEXT_PUBLIC_BUCKET_REGION: string;
     NEXT_PUBLIC_ACCESS_KEY: string;
     NEXT_PUBLIC_SECRET_KEY: string;
-    NEXT_PUBLIC_GOOGLE_ANALYTICS_TRACKING_ID: string;
+    NEXT_PUBLIC_AMPLITUDE_API_KEY: string;
   }
 }

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -7,6 +7,85 @@
   resolved "https://registry.yarnpkg.com/@alloc/quick-lru/-/quick-lru-5.2.0.tgz#7bf68b20c0a350f936915fcae06f58e32007ce30"
   integrity sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==
 
+"@amplitude/analytics-browser@^2.11.11":
+  version "2.11.11"
+  resolved "https://registry.yarnpkg.com/@amplitude/analytics-browser/-/analytics-browser-2.11.11.tgz#b41dea21ca97b8688b3e3acf392cc1481d5f9485"
+  integrity sha512-AdpNNPwoNPezojeeU2ITcyqKcrrW8edVBHlCEvDNIXYkf5Y0i5Blbes3x6rgONsOeV2hx85trTXhhVkilWgHcg==
+  dependencies:
+    "@amplitude/analytics-client-common" "^2.3.7"
+    "@amplitude/analytics-core" "^2.5.5"
+    "@amplitude/analytics-remote-config" "^0.4.0"
+    "@amplitude/analytics-types" "^2.8.4"
+    "@amplitude/plugin-autocapture-browser" "^1.0.2"
+    "@amplitude/plugin-page-view-tracking-browser" "^2.3.7"
+    tslib "^2.4.1"
+
+"@amplitude/analytics-client-common@>=1 <3", "@amplitude/analytics-client-common@^2.3.7":
+  version "2.3.7"
+  resolved "https://registry.yarnpkg.com/@amplitude/analytics-client-common/-/analytics-client-common-2.3.7.tgz#f943325ea317eb89c2eb92291fff19e4b4a3e3ea"
+  integrity sha512-HuwP2MFoeCTZWFIxkeYZOy5GP9ydjRO+n2KUMhHXTXGUx1M9vxIx1BUHsHKOZ4BZ5qEUTacgmznyc6uJJUiCWg==
+  dependencies:
+    "@amplitude/analytics-connector" "^1.4.8"
+    "@amplitude/analytics-core" "^2.5.5"
+    "@amplitude/analytics-types" "^2.8.4"
+    tslib "^2.4.1"
+
+"@amplitude/analytics-connector@^1.4.8":
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/@amplitude/analytics-connector/-/analytics-connector-1.6.2.tgz#0c0da82fe4722061591c1c5b75d7f585b95cb292"
+  integrity sha512-9bk2IjyV3VgUdbI3ounKUuP+4u4ABftDWGdOKxshEQrHg6WhgC8V4hdhSHv9wOHebGTvZntRKM5LlSXUyDYBpw==
+  dependencies:
+    "@amplitude/experiment-core" "^0.10.1"
+
+"@amplitude/analytics-core@>=1 <3", "@amplitude/analytics-core@^2.5.5":
+  version "2.5.5"
+  resolved "https://registry.yarnpkg.com/@amplitude/analytics-core/-/analytics-core-2.5.5.tgz#2df29bc1607bfbf23b531413c0dc8d0c4ac9bc59"
+  integrity sha512-OSB1WSD6qYoHyHliZaSujyatik2SP+vtoy8Y0vgRdYIpbE24F2q+SwBF3X5A1IeUqZ5fdpz+BNMwwUVl0Z4Ykg==
+  dependencies:
+    "@amplitude/analytics-types" "^2.8.4"
+    tslib "^2.4.1"
+
+"@amplitude/analytics-remote-config@^0.4.0":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@amplitude/analytics-remote-config/-/analytics-remote-config-0.4.1.tgz#b62cf8aa82290f68b314197e20351b10ea44ae3e"
+  integrity sha512-BYl6kQ9qjztrCACsugpxO+foLaQIC0aSEzoXEAb/gwOzInmqkyyI+Ub+aWTBih4xgB/lhWlOcidWHAmNiTJTNw==
+  dependencies:
+    "@amplitude/analytics-client-common" ">=1 <3"
+    "@amplitude/analytics-core" ">=1 <3"
+    "@amplitude/analytics-types" ">=1 <3"
+    tslib "^2.4.1"
+
+"@amplitude/analytics-types@>=1 <3", "@amplitude/analytics-types@^2.8.2", "@amplitude/analytics-types@^2.8.4":
+  version "2.8.4"
+  resolved "https://registry.yarnpkg.com/@amplitude/analytics-types/-/analytics-types-2.8.4.tgz#0d9ec0d3a0d00b729b5520b38ef8a158e691ffd2"
+  integrity sha512-jQ8WY1aPbpBshl0L/0YEeQn/wZlBr8Jlqc20qf8nbuDuimFy8RqAkE+BVaMI86FCkr3AJ7PjMXkGwCSbUx88CA==
+
+"@amplitude/experiment-core@^0.10.1":
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/@amplitude/experiment-core/-/experiment-core-0.10.1.tgz#85bb0bf55b419fe1b7bcee428182ed1eda010ff3"
+  integrity sha512-2h0vqOaHoACmNiliGT78hnu9K/tmb7pWU1xw1KitlTtxK6wQqsY/IZPLMwBMG5MLp/AOzNEA/uelODfhBC5+SQ==
+  dependencies:
+    js-base64 "^3.7.5"
+
+"@amplitude/plugin-autocapture-browser@^1.0.2":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@amplitude/plugin-autocapture-browser/-/plugin-autocapture-browser-1.0.4.tgz#ac1ed156c565bf6767ee7474110aa00f9ebca56c"
+  integrity sha512-+aUSsH4hRX4bWtSL90S3Irb3JctvIM+6aQ/wRSo1bYtnpXp7JQjWKzTYVxKx41b92Cb5DCBvmYgcWyg75BKi9Q==
+  dependencies:
+    "@amplitude/analytics-client-common" ">=1 <3"
+    "@amplitude/analytics-types" "^2.8.2"
+    rxjs "^7.8.1"
+    tslib "^2.4.1"
+
+"@amplitude/plugin-page-view-tracking-browser@^2.3.7":
+  version "2.3.7"
+  resolved "https://registry.yarnpkg.com/@amplitude/plugin-page-view-tracking-browser/-/plugin-page-view-tracking-browser-2.3.7.tgz#a19e295e5a83c7f29ea02b987ceae2d17453c860"
+  integrity sha512-9LEzU33vpQ1OdPwVn0nwcCqPLkfK3P19hLmFTflx+aBM70TH9xCwvJL6nJ5eyc4kkmE9x7r0mRVnQIxaHfTxGg==
+  dependencies:
+    "@amplitude/analytics-client-common" "^2.3.7"
+    "@amplitude/analytics-types" "^2.8.4"
+    tslib "^2.4.1"
+
 "@emnapi/runtime@^1.2.0":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@emnapi/runtime/-/runtime-1.3.1.tgz#0fcaa575afc31f455fd33534c19381cfce6c6f60"
@@ -2122,6 +2201,11 @@ jmespath@0.16.0:
   resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.16.0.tgz#b15b0a85dfd4d930d43e69ed605943c802785076"
   integrity sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==
 
+js-base64@^3.7.5:
+  version "3.7.7"
+  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-3.7.7.tgz#e51b84bf78fbf5702b9541e2cb7bfcb893b43e79"
+  integrity sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw==
+
 "js-tokens@^3.0.0 || ^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -3289,6 +3373,13 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
+rxjs@^7.8.1:
+  version "7.8.1"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.8.1.tgz#6f6f3d99ea8044291efd92e7c7fcf562c4057543"
+  integrity sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==
+  dependencies:
+    tslib "^2.1.0"
+
 safe-array-concat@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/safe-array-concat/-/safe-array-concat-1.1.3.tgz#c9e54ec4f603b0bbb8e7e5007a5ee7aecd1538c3"
@@ -3727,7 +3818,7 @@ tsconfig-paths@^3.15.0:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@^2.4.0, tslib@^2.8.0:
+tslib@^2.1.0, tslib@^2.4.0, tslib@^2.4.1, tslib@^2.8.0:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==


### PR DESCRIPTION
## issue

- close #26 

## 구현 사항
### Amplitude 연결
@amplitude/analytics-browser를 사용하여 amplitude를 연결했습니다.

### Init 설정
```tsx
init(process.env.NEXT_PUBLIC_AMPLITUDE_API_KEY, {
  autocapture: {
    elementInteractions: false, // 직접 track 메서드로 이벤트 발생
    fileDownloads: false, // 파일 다운로드 할 것 없음
    sessions: false, // 로그인이 없어 필요없음
    formInteractions: false, // 폼 태그를 트래킹 할 필요 없음
  },
});
```

autocapture 옵션으로 사용하지 않을 event를 false로 비활성화 했습니다.

### 문서 수정, 생성 트래킹 코드 연결
문서가 수정되고 생성될 때 트래킹 코드를 연결하여 이벤트가 발생합니다.
이 이벤트를 추적하여 수정과 생성의 빈도를 측정할 예정입니다.


## 🫡 참고사항
트래킹 코드는 추후에 더 보강될 수 있습니다.