### PR TITLE
편집로그가 쌓이지 않는 버그 수정

### DIFF
--- a/client/src/app/api/post-document/route.ts
+++ b/client/src/app/api/post-document/route.ts
@@ -15,6 +15,7 @@ const postDocument = async (document: PostDocumentContent) => {
   });
 
   revalidateTag(CACHE.tag.getRecentlyDocuments);
+  revalidateTag(CACHE.tag.getDocumentLogsByTitle(document.title));
   return response;
 };
 

--- a/client/src/app/api/put-document/route.ts
+++ b/client/src/app/api/put-document/route.ts
@@ -21,6 +21,7 @@ const putDocument = async (document: PostDocumentContent) => {
 
   revalidateTag(CACHE.tag.getRecentlyDocuments);
   revalidateTag(CACHE.tag.getDocumentByTitle(document.title));
+  revalidateTag(CACHE.tag.getDocumentLogsByTitle(document.title));
 
   return response;
 };


### PR DESCRIPTION
## issue

- close #42 

## 구현 사항
문서 편집과 등록할 때 편집 로그 revalidate 처리를 해주지 않아서 생겼던 문제입니다

아래 getDocumentLogsByTitle를 추가해서 해결했어요!
```ts
  revalidateTag(CACHE.tag.getRecentlyDocuments);
  revalidateTag(CACHE.tag.getDocumentByTitle(document.title));
  revalidateTag(CACHE.tag.getDocumentLogsByTitle(document.title));
```

## 🫡 참고사항
