### PR TITLE
문서 수정 후 다시 수정 접속 시 최신의 수정 내용이 보이지 않는 버그

### DIFF
--- a/client/src/hooks/fetch/useGetDocumentByTitle.ts
+++ b/client/src/hooks/fetch/useGetDocumentByTitle.ts
@@ -10,6 +10,7 @@ export const useGetDocumentByTitle = (title: string) => {
     const response = await requestGet<WikiDocument>({
       baseUrl: process.env.NEXT_PUBLIC_BASE_URL,
       endpoint: `/api/get-document-by-title?title=${title}`,
+      cache: 'no-cache',
     });
 
     return response;


### PR DESCRIPTION
## issue

- close #48 

## 구현 사항
client 서버로 보내는 get document title cache 설정을 no cache로 설정해서, 서버에서 revalidate tag가 호출된 후 client 서버로 문서 get 요청을 날릴 때 no cache 설정을 주어서, 최신의 데이터를 받을 수 있게 했습니다.

이 설정은 서버 컴포넌트에서 실행되는 getDocumentByTitle과는 다릅니다.


## 🫡 참고사항
