### PR TITLE
중복 문서 찾아내지 못함, 새로운 문서 생성 후 참조 불가 버그

### DIFF
--- a/client/src/components/document/Write/TitleInputField.tsx
+++ b/client/src/components/document/Write/TitleInputField.tsx
@@ -13,7 +13,7 @@ const TitleInputField = ({disabled = false}: TitleInputField) => {
   const {title, onTitleChange, onTitleBlur, titleErrorMessage} = titleProps;
   const {writer, onWriterChange, writerErrorMessage} = writerProps;
 
-  const {titles} = useSearchDocumentByQuery('');
+  const {titles} = useSearchDocumentByQuery(title);
 
   return (
     <div className="flex flex-col gap-2 w-full">

--- a/client/src/hooks/fetch/useGetRecentlyDocuments.ts
+++ b/client/src/hooks/fetch/useGetRecentlyDocuments.ts
@@ -10,6 +10,7 @@ export const useGetRecentlyDocuments = () => {
     const documents = requestGet<RecentlyDocument[]>({
       baseUrl: process.env.NEXT_PUBLIC_BASE_URL,
       endpoint: '/api/get-recently-documents',
+      cache: 'no-cache',
     });
 
     return documents;

--- a/client/src/hooks/fetch/useSearchDocumentByQuery.ts
+++ b/client/src/hooks/fetch/useSearchDocumentByQuery.ts
@@ -9,6 +9,7 @@ const getSearchDocument = async (query: string) => {
   const response = await requestGet<string[]>({
     baseUrl: process.env.NEXT_PUBLIC_BASE_URL,
     endpoint: `/api/get-search-document?referQuery=${query}`,
+    cache: 'no-cache',
   });
 
   return response;
@@ -26,7 +27,7 @@ const useSearchDocumentByQuery = (query: string, options?: UseSearchDocumentByQu
     if (query.trim() !== '' && /^[가-힣()0-9]*$/.test(query)) refetch();
   }, [query, refetch]);
 
-  const debouncedSearchDocuments = useDebounce(searchDocumentsIfValid, 200);
+  const debouncedSearchDocuments = useDebounce(searchDocumentsIfValid, 100);
 
   useEffect(() => {
     debouncedSearchDocuments();


### PR DESCRIPTION
## issue

- close #50 

## 구현 사항
### 중복 문서를 잡아내지 못하는 버그 해결
useSearchDocumentByQuery 훅의 파라미터에 query를 넣어줘야 하지만 그렇지 못 해서... 넣어서 해결했습니다.

### 새로운 문서를 제작한 뒤에 참조 불가능 버그 수정
이 역시 클라이언트에서 프론트 서버로 요청을 보낼 때 no-cache 값을 주지 않아서 생긴 버그,, 해결했습니다.

## 🫡 참고사항
