### PR TITLE
문서 조회 실패 버그 해결

### DIFF
--- a/client/src/components/document/TOC/TOC.tsx
+++ b/client/src/components/document/TOC/TOC.tsx
@@ -49,13 +49,18 @@ function convertToTOCNumber(list: number[]) {
 }
 
 const getHTagOrder = (heading: string) => {
-  const match = heading.match(/^<h(\d)/)!;
+  const match = heading.match(/^<h(\d)/);
+
+  if (!match) {
+    console.error('Invalid heading:', heading);
+    return -1;
+  }
+
   return parseInt(match[1], 10);
 };
 
 const TOC = ({headTags}: TOCProps) => {
   const tocList: IToc[] = [];
-
   const headTagsToNumber = headTags.map(heading => getHTagOrder(heading));
 
   const tocNumber = convertToTOCNumber(headTagsToNumber);

--- a/client/src/utils/addDataIdToToc.ts
+++ b/client/src/utils/addDataIdToToc.ts
@@ -1,9 +1,8 @@
 export const addDataIdToToc = (html: string) => {
   let idCounter = 0;
 
-  const updatedHtml = html.replace(/<(h[1-3])([^>]*)>/g, (_, tag, attributes) => {
-    return `<${tag} data-id="${idCounter++}"${attributes}>`;
+  return html.replace(/<(h[1-3])([^>]*)>/g, (_, tag, attributes) => {
+    const space = attributes.trim() ? ' ' : '';
+    return `<${tag} data-id="${idCounter++}"${space}${attributes}>`;
   });
-
-  return updatedHtml;
 };


### PR DESCRIPTION
## issue

- close #52 

## 예외 상황 두 가지
- heading 태그를 제대로 파싱 하지 못하는 문제
- 히스타, 히스타(7기)처럼 뒤에 붙을 때 전 문서를 가져오지 못하는 문제

## 구현 사항

### html 파서가 heading 태그를 제대로 파싱하지 못 할 때 예외 처리 추가

사용자가 문서를 작성했을 때 이 오류가 날 가능성이 두 가지 있습니다.

1. 마크다운 to html로 변환할 때 개행의 오류
2. 사용자가 직접 마크다운이 아닌 html로 입력했을 때 h태그 문법을 틀린 상황

아래는 루키(7기) 문서를 보면서 발견한 버그인데, 아마 이 경우는 사용자가 직접 html로 작성한 듯 보였습니다.
그러나 ```<h2>기부천사<h2> 와 같이 </h2>가 아닌 <h2>```로 html 문법을 틀리게 작성한 것 같았습니다.

TOC를 만드는 과정에서 아래 heading 태그를 match를 사용해서 가져올 때 !으로 없을 때도 타입 에러가 나지 않게 했었는데, 여기서 에러가 발생했습니다. match[1]을 접근하려고 할 때 match가 undefined여서 에러를 발생 시켰던 것이 500에러의 원인이었습니다.

```tsx
const match = heading.match(/^<h(\d)/)!;
return parseInt(match[1], 10);
```

그래서 이를 해결하고자 아래와 같이 !를 떼고 match가 없을 때 임의의 값 -1을 돌려주도록 해서 다른 곳을 가리킬지언정 프로그램이 에러가 나지 않도록 설정했습니다.

```tsx
const getHTagOrder = (heading: string) => {
  const match = heading.match(/^<h(\d)/);

  if (!match) {
    console.error('Invalid heading:', heading);
    return -1;
  }

  return parseInt(match[1], 10);
};
```

사용자 입력에 따른 에러 처리를 똑바로 해주지 않으면 이렇게 페이지가 다운될 수 있다는 좋은 경험을 했습니다 :)


### 전 문서를 가져오지 못하는 에러

처음에 황당했던 것이 배포 환경에서는 에러가 났지만, 로컬에서 개발 서버로 띄워봤을 때는 정상적으로 백엔드로 문서를 요청했다는 것입니다;;; 갈피를 못 잡다가 ec2에서 pm2의 에러 로그를 확인해봤습니다.

<img width="505" alt="pm2 에러 확인" src="https://github.com/user-attachments/assets/5ea1d90d-5493-4d3a-b7c9-0292e232410a" />

/wiki/[title]/page.js에서 문제가 일어난다는 것을 보고 정적 파일을 만드는데 문제가 있나 추측을 했습니다. 아까 Cannot read properties of null (reading "1") 이 문제가 아까 위에 루키(7기) 문서인데, 이 상황에서도 똑같은 에러 메시지를 내는 모습이 보였습니다. 그래서 위 문제를 해결한 뒤 로컬에서 빌드하니 문제가 일어나지 않았고, 배포 환경에서도 (이 코드를 먼저 배포하고) 다시 빌드해보니 문제가 사라졌습니다... 정말 어렵다.

### pm2에서 에러 로그를 보는 명령어
ec2 인스턴스에서 `tail -f ~/.pm2/logs/<pm2-name>-error.log` 를 입력하면 실시간으로 무슨 에러가 발생하고 있는지 확인할 수 있습니다.


## 🫡 참고사항
