### PR TITLE
DocumentTitle 컴포넌트 className 오타 수정

### DIFF
--- a/client/src/components/document/layout/DocumentTitle.tsx
+++ b/client/src/components/document/layout/DocumentTitle.tsx
@@ -1,5 +1,5 @@
 const DocumentTitle = (props: {title: string}) => {
-  return <h1 className="font-bm text-3xl text-greyscale-800">{props.title}</h1>;
+  return <h1 className="font-bm text-3xl text-grayscale-800">{props.title}</h1>;
 };
 
 export default DocumentTitle;


### PR DESCRIPTION
## issue

- close #65 

## 구현 사항

### DocumentTitle 컴포넌트
```tsx
const DocumentTitle = (props: {title: string}) => {
  return <h1 className="font-bm text-3xl text-greyscale-800">{props.title}</h1>;
};

export default DocumentTitle;
```
- 현재 위 코드에서 text-greyscale-800 에서 `greyscale` 오타가 있어서 `tailwind.config.js` 에서 사용자 정의한 색상이 적용이 안되는 문제를 해결하였습니다.
- `grayscale`로 오타 수정했습니다.

### tailwind.config.js
```tsx
        grayscale: {
          50: '#F3F4F6',
          100: '#E3E3E7',
          200: '#D9DADC',
          300: '#C7C8CA',
          400: '#9FA0A2',
          500: '#77787A',
          600: '#4F5052',
          700: '#36383D',
          800: '#27282A',
          900: '#18191A',
          container: '#F3F4F6',
          border: '#E3E3E7',
          lightText: '#9FA0A2',
          text: '#27282A',
        },
```


## 🫡 참고사항

![image](https://github.com/user-attachments/assets/7b30cc3b-c796-4dec-8c62-9139b9ff63e2)

