### PR TITLE
인기있는 문서 페이지 추가

### DIFF
--- a/client/src/app/wiki/popular/page.tsx
+++ b/client/src/app/wiki/popular/page.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import {useGetPopularDocuments} from '@hooks/fetch/useGetPopularDocuments';
+import PopularRankingCard from '@components/document/Popular/PopularRankingCard';
+import PopularDocumentList from '@components/document/Popular/PopularDocumentList';
+import PopularHeader from '@components/document/Popular/PopularHeader';
+
+export default function PopularPage() {
+  const {data, sortType, changeSortType} = useGetPopularDocuments();
+
+  const topThreeDocuments = data.slice(0, 3);
+  const remainDocuments = data.slice(3);
+
+  return (
+    <div className="flex w-full flex-col gap-6 max-[768px]:gap-2">
+      <section className="flex h-fit min-h-[864px] w-full flex-col gap-6 rounded-xl border border-solid border-primary-100 bg-white p-8 max-md:p-4">
+        <PopularHeader sortType={sortType} onSortTypeChange={changeSortType} />
+
+        {/* 상위 3개 항목 - 금/은/동 */}
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+          {topThreeDocuments.map((document, index) => (
+            <PopularRankingCard key={document.title} document={document} rank={index + 1} sortType={sortType} />
+          ))}
+        </div>
+
+        <PopularDocumentList documents={remainDocuments} sortType={sortType} />
+      </section>
+    </div>
+  );
+}

--- a/client/src/app/wiki/popular/page.tsx
+++ b/client/src/app/wiki/popular/page.tsx
@@ -5,7 +5,7 @@ import PopularRankingCard from '@components/document/Popular/PopularRankingCard'
 import PopularDocumentList from '@components/document/Popular/PopularDocumentList';
 import PopularHeader from '@components/document/Popular/PopularHeader';
 
-export default function PopularPage() {
+const PopularPage = () => {
   const {data, sortType, changeSortType} = useGetPopularDocuments();
 
   const topThreeDocuments = data.slice(0, 3);
@@ -27,4 +27,6 @@ export default function PopularPage() {
       </section>
     </div>
   );
-}
+};
+
+export default PopularPage;

--- a/client/src/app/wiki/popular/page.tsx
+++ b/client/src/app/wiki/popular/page.tsx
@@ -8,8 +8,9 @@ import PopularHeader from '@components/document/Popular/PopularHeader';
 const PopularPage = () => {
   const {data, sortType, changeSortType} = useGetPopularDocuments();
 
-  const topThreeDocuments = data.slice(0, 3);
-  const remainDocuments = data.slice(3);
+  const topTenDocuments = data.slice(0, 10);
+  const topThreeDocuments = topTenDocuments.slice(0, 3);
+  const remainDocuments = topTenDocuments.slice(3);
 
   return (
     <div className="flex w-full flex-col gap-6 max-[768px]:gap-2">

--- a/client/src/components/document/Popular/PopularDocumentItem.tsx
+++ b/client/src/components/document/Popular/PopularDocumentItem.tsx
@@ -9,7 +9,7 @@ interface PopularDocumentItemProps {
   sortType: 'views' | 'edits';
 }
 
-export default function PopularDocumentItem({document, rank, sortType}: PopularDocumentItemProps) {
+const PopularDocumentItem = ({document, rank, sortType}: PopularDocumentItemProps) => {
   const primaryCount = sortType === 'views' ? document.viewCount : document.editCount;
   const secondaryCount = sortType === 'views' ? document.editCount : document.viewCount;
 
@@ -35,4 +35,6 @@ export default function PopularDocumentItem({document, rank, sortType}: PopularD
       </div>
     </Link>
   );
-}
+};
+
+export default PopularDocumentItem;

--- a/client/src/components/document/Popular/PopularDocumentItem.tsx
+++ b/client/src/components/document/Popular/PopularDocumentItem.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import Link from 'next/link';
+import {PopularDocument} from '@type/Document.type';
+
+interface PopularDocumentItemProps {
+  document: PopularDocument;
+  rank: number;
+  sortType: 'views' | 'edits';
+}
+
+export default function PopularDocumentItem({document, rank, sortType}: PopularDocumentItemProps) {
+  const primaryCount = sortType === 'views' ? document.viewCount : document.editCount;
+  const secondaryCount = sortType === 'views' ? document.editCount : document.viewCount;
+
+  return (
+    <Link href={`/wiki/${encodeURIComponent(document.title)}`}>
+      <div className="group flex cursor-pointer items-center border-b border-grayscale-100 px-2 py-4 transition-colors hover:bg-primary-50/30 md:px-4">
+        <div className="w-8 text-center text-sm font-semibold text-grayscale-600 md:w-12 md:text-base">{rank}</div>
+        <div className="min-w-0 flex-1 px-3 md:px-4">
+          <h3 className="truncate font-medium text-grayscale-800 transition-colors group-hover:text-primary-primary">
+            {document.title}
+          </h3>
+        </div>
+        {/* 주요 통계 (조회수 or 수정수) */}
+        <div className="mr-3 text-right md:mr-6">
+          <div className="font-semibold text-grayscale-800">{primaryCount.toLocaleString()}</div>
+          <div className="text-xs text-grayscale-500">{sortType === 'views' ? '조회' : '수정'}</div>
+        </div>
+        {/* 보조 통계 - 데스크탑에서만 표시됨 */}
+        <div className="hidden text-right md:block">
+          <div className="text-sm text-grayscale-600">{secondaryCount.toLocaleString()}</div>
+          <div className="text-xs text-grayscale-500">{sortType === 'views' ? '수정' : '조회'}</div>
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/client/src/components/document/Popular/PopularDocumentList.tsx
+++ b/client/src/components/document/Popular/PopularDocumentList.tsx
@@ -10,20 +10,27 @@ interface PopularDocumentListProps {
 }
 
 const PopularDocumentList = ({documents, sortType, startRank = 4}: PopularDocumentListProps) => {
-  if (documents.length === 0) {
-    return (
-      <div className="rounded-lg border border-gray-200 bg-gray-50 p-8 text-center text-gray-500">
-        등록된 문서가 없습니다.
-      </div>
-    );
-  }
+  const isDocumentEmpty = documents.length === 0;
 
   return (
-    <div className="flex flex-col gap-2">
-      {documents.map((document, index) => (
-        <PopularDocumentItem key={document.title} document={document} rank={startRank + index} sortType={sortType} />
-      ))}
-    </div>
+    <>
+      {isDocumentEmpty ? (
+        <div className="rounded-lg border border-gray-200 bg-gray-50 p-8 text-center text-gray-500">
+          등록된 문서가 없습니다.
+        </div>
+      ) : (
+        <div className="flex flex-col gap-2">
+          {documents.map((document, index) => (
+            <PopularDocumentItem
+              key={document.title}
+              document={document}
+              rank={startRank + index}
+              sortType={sortType}
+            />
+          ))}
+        </div>
+      )}
+    </>
   );
 };
 

--- a/client/src/components/document/Popular/PopularDocumentList.tsx
+++ b/client/src/components/document/Popular/PopularDocumentList.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import {PopularDocument} from '@type/Document.type';
+import PopularDocumentItem from './PopularDocumentItem';
+
+interface PopularDocumentListProps {
+  documents: PopularDocument[];
+  sortType: 'views' | 'edits';
+  startRank?: number;
+}
+
+export default function PopularDocumentList({documents, sortType, startRank = 4}: PopularDocumentListProps) {
+  if (documents.length === 0) {
+    return (
+      <div className="bg-gray-50 border border-gray-200 rounded-lg p-8 text-center text-gray-500">
+        등록된 문서가 없습니다.
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      {documents.map((document, index) => (
+        <PopularDocumentItem
+          key={document.title}
+          document={document}
+          rank={startRank + index}
+          sortType={sortType}
+        />
+      ))}
+    </div>
+  );
+}

--- a/client/src/components/document/Popular/PopularDocumentList.tsx
+++ b/client/src/components/document/Popular/PopularDocumentList.tsx
@@ -9,10 +9,10 @@ interface PopularDocumentListProps {
   startRank?: number;
 }
 
-export default function PopularDocumentList({documents, sortType, startRank = 4}: PopularDocumentListProps) {
+const PopularDocumentList = ({documents, sortType, startRank = 4}: PopularDocumentListProps) => {
   if (documents.length === 0) {
     return (
-      <div className="bg-gray-50 border border-gray-200 rounded-lg p-8 text-center text-gray-500">
+      <div className="rounded-lg border border-gray-200 bg-gray-50 p-8 text-center text-gray-500">
         등록된 문서가 없습니다.
       </div>
     );
@@ -21,13 +21,10 @@ export default function PopularDocumentList({documents, sortType, startRank = 4}
   return (
     <div className="flex flex-col gap-2">
       {documents.map((document, index) => (
-        <PopularDocumentItem
-          key={document.title}
-          document={document}
-          rank={startRank + index}
-          sortType={sortType}
-        />
+        <PopularDocumentItem key={document.title} document={document} rank={startRank + index} sortType={sortType} />
       ))}
     </div>
   );
-}
+};
+
+export default PopularDocumentList;

--- a/client/src/components/document/Popular/PopularFilterButtons.tsx
+++ b/client/src/components/document/Popular/PopularFilterButtons.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import Button from '@components/common/Button';
+
+interface PopularFilterButtonsProps {
+  sortType: 'views' | 'edits';
+  onSortTypeChange: (type: 'views' | 'edits') => void;
+}
+
+export default function PopularFilterButtons({sortType, onSortTypeChange}: PopularFilterButtonsProps) {
+  return (
+    <div className="flex gap-2">
+      <Button size="xs" style={sortType === 'views' ? 'primary' : 'tertiary'} onClick={() => onSortTypeChange('views')}>
+        조회수 기준
+      </Button>
+      <Button size="xs" style={sortType === 'edits' ? 'primary' : 'tertiary'} onClick={() => onSortTypeChange('edits')}>
+        수정수 기준
+      </Button>
+    </div>
+  );
+}

--- a/client/src/components/document/Popular/PopularFilterButtons.tsx
+++ b/client/src/components/document/Popular/PopularFilterButtons.tsx
@@ -7,7 +7,7 @@ interface PopularFilterButtonsProps {
   onSortTypeChange: (type: 'views' | 'edits') => void;
 }
 
-export default function PopularFilterButtons({sortType, onSortTypeChange}: PopularFilterButtonsProps) {
+const PopularFilterButtons = ({sortType, onSortTypeChange}: PopularFilterButtonsProps) => {
   return (
     <div className="flex gap-2">
       <Button size="xs" style={sortType === 'views' ? 'primary' : 'tertiary'} onClick={() => onSortTypeChange('views')}>
@@ -18,4 +18,6 @@ export default function PopularFilterButtons({sortType, onSortTypeChange}: Popul
       </Button>
     </div>
   );
-}
+};
+
+export default PopularFilterButtons;

--- a/client/src/components/document/Popular/PopularHeader.tsx
+++ b/client/src/components/document/Popular/PopularHeader.tsx
@@ -1,0 +1,20 @@
+import DocumentTitle from '@components/document/layout/DocumentTitle';
+import PopularFilterButtons from './PopularFilterButtons';
+
+interface PopularHeaderProps {
+  sortType: 'views' | 'edits';
+  onSortTypeChange: (type: 'views' | 'edits') => void;
+}
+
+const PopularHeader = ({sortType, onSortTypeChange}: PopularHeaderProps) => {
+  return (
+    <header className="flex justify-between w-full items-center mb-6 max-md:flex-col max-md:gap-4">
+      <DocumentTitle title="인기문서" />
+      <nav className="flex gap-2">
+        <PopularFilterButtons sortType={sortType} onSortTypeChange={onSortTypeChange} />
+      </nav>
+    </header>
+  );
+};
+
+export default PopularHeader;

--- a/client/src/components/document/Popular/PopularRankingCard.tsx
+++ b/client/src/components/document/Popular/PopularRankingCard.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import Link from 'next/link';
+import {PopularDocument} from '@type/Document.type';
+
+interface PopularRankingCardProps {
+  document: PopularDocument;
+  rank: number;
+  sortType: 'views' | 'edits';
+}
+
+const rankEmojis = ['🥇', '🥈', '🥉'];
+
+export default function PopularRankingCard({document, rank, sortType}: PopularRankingCardProps) {
+  const displayCount = sortType === 'views' ? document.viewCount : document.editCount;
+  const countLabel = sortType === 'views' ? '조회수' : '수정수';
+
+  return (
+    <Link href={`/wiki/${encodeURIComponent(document.title)}`}>
+      <div className="h-full rounded-lg border border-primary-100 bg-white p-6">
+        <div className="mb-4 flex items-center gap-3">
+          <span className="text-3xl">{rankEmojis[rank - 1]}</span>
+          <span className="text-lg font-semibold text-gray-600">{rank}위</span>
+        </div>
+
+        <h3 className="mb-3 line-clamp-2 text-lg font-bold text-gray-800">{document.title}</h3>
+
+        <div className="flex flex-col gap-2 text-sm text-gray-600">
+          <div className="flex justify-between">
+            <span>{countLabel}</span>
+            <span className="font-semibold">{displayCount.toLocaleString()}</span>
+          </div>
+          <div className="flex justify-between">
+            <span>{sortType === 'views' ? '수정수' : '조회수'}</span>
+            <span className="text-gray-500">
+              {sortType === 'views' ? document.editCount.toLocaleString() : document.viewCount.toLocaleString()}
+            </span>
+          </div>
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/client/src/components/document/Popular/PopularRankingCard.tsx
+++ b/client/src/components/document/Popular/PopularRankingCard.tsx
@@ -11,7 +11,7 @@ interface PopularRankingCardProps {
 
 const rankEmojis = ['🥇', '🥈', '🥉'];
 
-export default function PopularRankingCard({document, rank, sortType}: PopularRankingCardProps) {
+const PopularRankingCard = ({document, rank, sortType}: PopularRankingCardProps) => {
   const displayCount = sortType === 'views' ? document.viewCount : document.editCount;
   const countLabel = sortType === 'views' ? '조회수' : '수정수';
 
@@ -40,4 +40,6 @@ export default function PopularRankingCard({document, rank, sortType}: PopularRa
       </div>
     </Link>
   );
-}
+};
+
+export default PopularRankingCard;

--- a/client/src/hooks/fetch/useGetPopularDocuments.ts
+++ b/client/src/hooks/fetch/useGetPopularDocuments.ts
@@ -1,0 +1,96 @@
+import {useState} from 'react';
+import {PopularDocument} from '@type/Document.type';
+
+export const mockData: PopularDocument[] = [
+  {
+    title: '잠실캠 주변 맛집',
+    viewCount: 15234,
+    editCount: 342,
+  },
+  {
+    title: '루나(7기)',
+    viewCount: 12456,
+    editCount: 287,
+  },
+  {
+    title: '리바이(7기)',
+    viewCount: 11789,
+    editCount: 256,
+  },
+  {
+    title: '선릉캠 주변 맛집',
+    viewCount: 9876,
+    editCount: 198,
+  },
+  {
+    title: '칼리(7기)',
+    viewCount: 8765,
+    editCount: 176,
+  },
+  {
+    title: '밍트 (7기)',
+    viewCount: 7654,
+    editCount: 154,
+  },
+  {
+    title: '체체(7기)',
+    viewCount: 6543,
+    editCount: 132,
+  },
+  {
+    title: 'TypeScript 타입 시스템',
+    viewCount: 5432,
+    editCount: 110,
+  },
+  {
+    title: 'JPA 성능 최적화',
+    viewCount: 4321,
+    editCount: 98,
+  },
+  {
+    title: '도커 컨테이너 활용법',
+    viewCount: 3210,
+    editCount: 76,
+  },
+  {
+    title: '애자일 스크럼 가이드',
+    viewCount: 2987,
+    editCount: 65,
+  },
+];
+
+type SortType = 'views' | 'edits';
+
+export const useGetPopularDocuments = () => {
+  const [sortType, setSortType] = useState<SortType>('views');
+  const [isLoading, setIsLoading] = useState(false);
+
+  const sortedData = [...mockData].sort((a, b) => {
+    if (sortType === 'views') {
+      return b.viewCount - a.viewCount;
+    }
+    return b.editCount - a.editCount;
+  });
+
+  const showLoadingEffect = () => {
+    setIsLoading(true);
+    setTimeout(() => {
+      setIsLoading(false);
+    }, 300);
+  };
+
+  const changeSortType = (newSortType: SortType) => {
+    if (newSortType !== sortType) {
+      showLoadingEffect();
+      setSortType(newSortType);
+    }
+  };
+
+  return {
+    data: sortedData,
+    isLoading,
+    error: null,
+    sortType,
+    changeSortType,
+  };
+};

--- a/client/src/type/Document.type.ts
+++ b/client/src/type/Document.type.ts
@@ -41,6 +41,12 @@ export interface RecentlyDocument {
   generateTime: string;
 }
 
+export interface PopularDocument {
+  title: string;
+  viewCount: number;
+  editCount: number;
+}
+
 export type ErrorMessage = string | null;
 
 export type ErrorInfo = {


### PR DESCRIPTION
# 인기있는 문서 페이지

## issue

- close #73 

## 구현 사항

### 전반적인 기능 

https://github.com/user-attachments/assets/969dac95-55a2-4c91-a329-704e6540a221

### 반응형 UI

https://github.com/user-attachments/assets/31a37809-d734-4eb2-92b0-e4636e18ef21

### 구현 내용

- [x] 인기있는 문서 페이지 추가
- [x] 인기있는 문서 컴포넌트 추가
	- [x] 조회수, 수정수 별 필터 버튼 추가 & 데이터 정렬
	- [x] 상단 랭킹
	- [x] 하단 리스트
- [x] 반응형 UI 

1-3위는 금은동메달이 달린 카드 컴포넌트로 구현했어요.
4-10위는 간단한 아이템 컴포넌트로 구현했어요. 

반응형으로 만들어서 모바일 사이즈의 경우에는 선택된 정렬 기능에 해당하는 데이터만 노출되도록 했습니다~
 
### 일반

![CleanShot 2025-06-01 at 04 28 00@2x](https://github.com/user-attachments/assets/9d3e9fed-8715-4deb-9be7-48f0b97dc091)

### 모바일

![CleanShot 2025-06-01 at 04 26 46@2x](https://github.com/user-attachments/assets/409ee89f-fd1f-46c7-994f-0aabbe268bd2)


## 중점적으로 리뷰받고 싶은 부분(선택)

## 논의하고 싶은 부분(선택)

### 인기있는 문서의 기준

저번에 이야기 나왔던 조회순, 수정순으로 일단 구현은 해놨는데요, 
인기있는 문서를 어떤 기준으로 선정할 것인지 의논이 필요합니다.
현재 앰플리튜드를 보고 데이터를 수동으로 체크하고 있는데, 데이터를 어떻게 받아올지도 얘기해봐야 할 것 같네요!

## 🫡 참고사항

### URL 구조

URL을 어떻게 정할지 다음의 두가지를 두고 고민했어요.

1. https://www.crew-wiki.site/wiki/popular
2. https://www.crew-wiki.site/popular

저는 1번으로 선택해서 구현했는데 그 이유는 현재 프로젝트의 라우팅 구조와 맞추기 위해서였어요.
위키 관련 페이지가 `/wiki/post`, `/wiki/statistics` 이런식으로 되어있어서 저도 맞췄습니다~!
지금은 `/wiki/statistics` 페이지에 아무것도 없는데 나중에 popular 페이지로 전환해서 사용할 수도 있을 것 같다는 생각이 드네요!
처음에는 2번 방식이 짧고 간단해서 좋았는데 일관성을 해치는 느낌이라 최종으로는 1로 결정했어요. 😊
