### PR TITLE
이미지 확장자가 없는 파일 jpeg로 변경 및 대응

### DIFF
--- a/client/src/utils/processImageHtml.ts
+++ b/client/src/utils/processImageHtml.ts
@@ -4,7 +4,7 @@ export function processImageHtml(html: string): string {
 
   return html.replace(/<img\s+([^>]*?)src="([^"]+)"([^>]*?)>/g, (match, before, src, after) => {
     try {
-      let replacedSrc = src.replace(s3Domain, cloudfrontDomain);
+      const replacedSrc = src.replace(s3Domain, cloudfrontDomain);
 
       const url = new URL(replacedSrc);
       const pathParts = url.pathname.split('/');
@@ -16,9 +16,9 @@ export function processImageHtml(html: string): string {
       pathParts[pathParts.length - 1] = processedFilename;
       url.pathname = pathParts.join('/');
 
-      replacedSrc = url.toString();
+      const processedSrc = url.toString();
 
-      return `<img ${before}src="${replacedSrc}"${after}>`;
+      return `<img ${before}src="${processedSrc}"${after}>`;
     } catch {
       return match;
     }

--- a/client/src/utils/processImageHtml.ts
+++ b/client/src/utils/processImageHtml.ts
@@ -1,6 +1,6 @@
 export function processImageHtml(html: string): string {
-  const s3Domain = process.env.NEXT_PUBLIC_IMAGE_S3_DOMAIN!;
-  const cloudfrontDomain = process.env.NEXT_PUBLIC_IMAGE_CLOUDFRONT_DOMAIN!;
+  const s3Domain = process.env.NEXT_PUBLIC_IMAGE_S3_DOMAIN;
+  const cloudfrontDomain = process.env.NEXT_PUBLIC_IMAGE_CLOUDFRONT_DOMAIN;
 
   return html.replace(/<img\s+([^>]*?)src="([^"]+)"([^>]*?)>/g, (match, before, src, after) => {
     try {

--- a/client/src/utils/processImageHtml.ts
+++ b/client/src/utils/processImageHtml.ts
@@ -9,20 +9,13 @@ export function processImageHtml(html: string): string {
       const url = new URL(replacedSrc);
       const pathParts = url.pathname.split('/');
       const filename = pathParts[pathParts.length - 1];
-      const dotIndex = filename.lastIndexOf('.');
 
-      if (dotIndex === -1) {
-        pathParts[pathParts.length - 1] = `${filename}.jpeg`;
-      } else {
-        const baseName = filename.substring(0, dotIndex);
-        const ext = filename.substring(dotIndex + 1).toLowerCase();
+      const hasExtension = /\.(jpeg|jpg|png|gif|webp)$/i.test(filename);
+      const processedFilename = hasExtension ? filename : `${filename.replace(/\.[^/.]+$/, '')}.jpeg`;
 
-        if (ext !== 'jpeg') {
-          pathParts[pathParts.length - 1] = `${baseName}.jpeg`;
-        }
-      }
-
+      pathParts[pathParts.length - 1] = processedFilename;
       url.pathname = pathParts.join('/');
+
       replacedSrc = url.toString();
 
       return `<img ${before}src="${replacedSrc}"${after}>`;

--- a/client/src/utils/processImageHtml.ts
+++ b/client/src/utils/processImageHtml.ts
@@ -1,10 +1,29 @@
 export function processImageHtml(html: string): string {
-  const s3Domain = process.env.NEXT_PUBLIC_IMAGE_S3_DOMAIN;
-  const cloudfrontDomain = process.env.NEXT_PUBLIC_IMAGE_CLOUDFRONT_DOMAIN;
+  const s3Domain = process.env.NEXT_PUBLIC_IMAGE_S3_DOMAIN!;
+  const cloudfrontDomain = process.env.NEXT_PUBLIC_IMAGE_CLOUDFRONT_DOMAIN!;
 
   return html.replace(/<img\s+([^>]*?)src="([^"]+)"([^>]*?)>/g, (match, before, src, after) => {
     try {
-      const replacedSrc = src.replace(s3Domain, cloudfrontDomain);
+      let replacedSrc = src.replace(s3Domain, cloudfrontDomain);
+
+      const url = new URL(replacedSrc);
+      const pathParts = url.pathname.split('/');
+      const filename = pathParts[pathParts.length - 1];
+      const dotIndex = filename.lastIndexOf('.');
+
+      if (dotIndex === -1) {
+        pathParts[pathParts.length - 1] = `${filename}.jpeg`;
+      } else {
+        const baseName = filename.substring(0, dotIndex);
+        const ext = filename.substring(dotIndex + 1).toLowerCase();
+
+        if (ext !== 'jpeg') {
+          pathParts[pathParts.length - 1] = `${baseName}.jpeg`;
+        }
+      }
+
+      url.pathname = pathParts.join('/');
+      replacedSrc = url.toString();
 
       return `<img ${before}src="${replacedSrc}"${after}>`;
     } catch {


### PR DESCRIPTION
## issue

- close #78 

## 구현 사항

### S3 내 이미지 확장자 생성
S3 내 모든 이미지 객체에 jpeg 확장자를 붙였습니다. 이전에 AWS 이전을 하며 백업해 둔 이미지가 있었고 그 이미지 정보를 사용해서 확장자가 없는 파일을 jpeg로 덮어 씌웠습니다.

![image](https://github.com/user-attachments/assets/403dfeca-1a2f-45c8-b4a1-33f811763bbd)

### 이미지 요청 시 jpeg로 고정
이전에는 확장자가 없는 파일을 요청할 때 `https://~~~/쿠키(6기)/값` 으로 요청을 했는데, 이제는 `https://~~~/쿠키(6기)/값.jpeg`로 요청하기 때문에 이미지를 요청할 때 이미지를 가져오지 못하는 버그가 생길 수 있다고 생각했습니다.
그래서 이미지를 요청하기 전 가공을 해서 이미지 요청 url 뒤에 전부 jpeg를 붙이도록 설정했습니다

1) 확장자가 없으면 jpeg
2) 확장자가 있는데 jpeg가 아니라면 jpeg로 변경

## 🫡 참고사항
