### PR TITLE
문서 편집로그 페이지네이션으로 불러오는 기능 구현

### DIFF
--- a/client/src/apis/client/document.ts
+++ b/client/src/apis/client/document.ts
@@ -2,7 +2,8 @@
 
 import {ENDPOINT} from '@constants/endpoint';
 import {requestGetClient, requestPostClient, requestPutClient} from '@http/client';
-import {PostDocumentContent, WikiDocument} from '@type/Document.type';
+import {PostDocumentContent, WikiDocument, WikiDocumentLogSummary} from '@type/Document.type';
+import {PaginationParams, PaginationResponse} from '@type/General.type';
 
 export const getDocumentByTitleClient = async (title: string) => {
   const response = await requestGetClient<WikiDocument>({
@@ -43,6 +44,16 @@ export const getSearchDocumentClient = async (query: string) => {
     queryParams: {
       keyWord: query,
     },
+  });
+
+  return response;
+};
+
+export const getDocumentLogsByUUIDClient = async (uuid: string, params: PaginationParams) => {
+  const response = await requestGetClient<PaginationResponse<WikiDocumentLogSummary[]>>({
+    baseUrl: process.env.NEXT_PUBLIC_BACKEND_SERVER_BASE_URL,
+    endpoint: ENDPOINT.getDocumentLogsByUUID(uuid),
+    queryParams: params,
   });
 
   return response;

--- a/client/src/apis/server/document.ts
+++ b/client/src/apis/server/document.ts
@@ -11,7 +11,7 @@ import {
 } from '@type/Document.type';
 import {requestGetServer, requestPostServer, requestPutServer} from '@http/server';
 import {PaginationParams, PaginationResponse} from '@type/General.type';
-import {allDocumentsParams, recentlyParams} from '@constants/params';
+import {allDocumentsParams, documentLogsParams, recentlyParams} from '@constants/params';
 
 export const getDocumentsServerWithPagination = async (params: PaginationParams) => {
   const response = await requestGetServer<PaginationResponse<WikiDocumentExpand[]>>({
@@ -57,15 +57,14 @@ export const getDocumentByUUIDServer = async (uuid: string) => {
 };
 
 export const getDocumentLogsByUUIDServer = async (uuid: string) => {
-  const logs = await requestGetServer<WikiDocumentLogSummary[]>({
+  const response = await requestGetServer<PaginationResponse<WikiDocumentLogSummary[]>>({
     baseUrl: process.env.NEXT_PUBLIC_BACKEND_SERVER_BASE_URL,
     endpoint: ENDPOINT.getDocumentLogsByUUID(uuid),
+    queryParams: documentLogsParams,
     next: {revalidate: CACHE.time.basicRevalidate, tags: [CACHE.tag.getDocumentLogsByUUID(uuid)]},
   });
 
-  return logs.sort((a: WikiDocumentLogSummary, b: WikiDocumentLogSummary) =>
-    a.generateTime <= b.generateTime ? 1 : -1,
-  );
+  return response;
 };
 
 export const getSpecificDocumentLogServer = async (logId: number) => {

--- a/client/src/app/wiki/[uuid]/logs/LogContent.tsx
+++ b/client/src/app/wiki/[uuid]/logs/LogContent.tsx
@@ -9,11 +9,11 @@ type LogContentProps = {
 };
 
 export const LogContent = ({uuid, summary}: LogContentProps) => {
-  const {logId, version, generateTime, documentBytes, writer} = summary;
+  const {id, version, generateTime, documentBytes, writer} = summary;
 
   return (
     <Link
-      href={`${URLS.wiki}/${uuid}/log/${logId}`}
+      href={`${URLS.wiki}/${uuid}/log/${id}`}
       passHref
       className="text-md flex w-full items-center justify-center gap-2 rounded-2xl border border-primary-100 px-2 py-4 font-pretendard text-grayscale-800 md:gap-8"
     >

--- a/client/src/app/wiki/[uuid]/logs/LogList.tsx
+++ b/client/src/app/wiki/[uuid]/logs/LogList.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import {InfiniteScrollObserver} from '@components/common/InfinityScrollObserver';
+import {LogContent} from './LogContent';
+import {WikiDocumentLogSummary} from '@type/Document.type';
+import {useGetDocumentLogs} from '@hooks/fetch/useGetDocumentLogs';
+
+type LogListParams = {
+  uuid: string;
+  initialData: WikiDocumentLogSummary[];
+  totalPage: number;
+};
+
+export const LogList = ({uuid, initialData, totalPage}: LogListParams) => {
+  const {logs, fetchNextPage} = useGetDocumentLogs(uuid, initialData, totalPage);
+
+  return (
+    <div className="flex flex-col gap-4">
+      {logs?.map(log => <LogContent key={log.id} uuid={uuid} summary={log} />)}
+      <InfiniteScrollObserver key={uuid} callback={fetchNextPage} />
+    </div>
+  );
+};

--- a/client/src/app/wiki/[uuid]/logs/page.tsx
+++ b/client/src/app/wiki/[uuid]/logs/page.tsx
@@ -1,8 +1,8 @@
 import type {UUIDLogParams, UUIDParams} from '@type/PageParams.type';
-import {LogContent} from './LogContent';
 import {Metadata} from 'next';
 import {getDocumentLogsByUUIDServer} from '@apis/server/document';
 import {getDocumentTitleUsingUUID} from '@utils/getDocumentUsingUUIDInCache';
+import {LogList} from './LogList';
 
 export async function generateMetadata({params}: UUIDLogParams): Promise<Metadata> {
   const {uuid} = await params;
@@ -20,7 +20,7 @@ export async function generateMetadata({params}: UUIDLogParams): Promise<Metadat
 
 const Page = async ({params}: UUIDParams) => {
   const {uuid} = await params;
-  const documentLogs = await getDocumentLogsByUUIDServer(uuid);
+  const response = await getDocumentLogsByUUIDServer(uuid);
 
   return (
     <div className="flex w-full flex-col gap-4">
@@ -38,9 +38,7 @@ const Page = async ({params}: UUIDParams) => {
           <p className="w-full text-center font-bold">편집자</p>
         </div>
       </div>
-      <div className="flex flex-col gap-4">
-        {documentLogs?.map(docs => <LogContent key={docs.logId} uuid={uuid as string} summary={docs} />)}
-      </div>
+      <LogList key={uuid} uuid={uuid} initialData={response.data} totalPage={response.totalPage} />
     </div>
   );
 };

--- a/client/src/components/common/InfinityScrollObserver/index.tsx
+++ b/client/src/components/common/InfinityScrollObserver/index.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import {useRef, useEffect} from 'react';
+
+type InfiniteScrollObserverProps = {
+  threshold?: number | number[] | undefined;
+  callback: () => void;
+};
+
+export const InfiniteScrollObserver = ({callback, threshold = 0.3}: InfiniteScrollObserverProps) => {
+  const targetRef = useRef<HTMLDivElement | null>(null);
+  const observerRef = useRef<IntersectionObserver | null>(null);
+
+  useEffect(() => {
+    if (!targetRef.current) return;
+
+    if (observerRef.current) {
+      observerRef.current.disconnect();
+    }
+
+    observerRef.current = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          callback();
+        }
+      },
+      {threshold},
+    );
+
+    observerRef.current.observe(targetRef.current);
+
+    return () => {
+      observerRef.current?.disconnect();
+    };
+  }, [callback, threshold]);
+
+  return <div ref={targetRef} style={{height: 1}} />;
+};

--- a/client/src/constants/params.ts
+++ b/client/src/constants/params.ts
@@ -13,3 +13,10 @@ export const allDocumentsParams: PaginationParams = {
   sort: 'generateTime',
   sortDirection: 'ASC',
 };
+
+export const documentLogsParams: PaginationParams = {
+  pageNumber: 0,
+  pageSize: 10,
+  sort: 'id',
+  sortDirection: 'DESC',
+};

--- a/client/src/hooks/fetch/useGetDocumentLogs.ts
+++ b/client/src/hooks/fetch/useGetDocumentLogs.ts
@@ -1,0 +1,35 @@
+import {getDocumentLogsByUUIDClient} from '@apis/client/document';
+import {WikiDocumentLogSummary} from '@type/Document.type';
+import {useEffect, useState} from 'react';
+
+export const useGetDocumentLogs = (uuid: string, initialData: WikiDocumentLogSummary[], totalPage: number) => {
+  const [page, setPage] = useState(0);
+  const [data, setData] = useState<WikiDocumentLogSummary[]>(initialData);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const response = await getDocumentLogsByUUIDClient(uuid, {
+        pageNumber: page,
+        pageSize: 10,
+        sort: 'ID',
+        sortDirection: 'DESC',
+      });
+
+      setData(prev => [...prev, ...response.data]);
+    };
+
+    if (page > 0) {
+      fetchData();
+    }
+  }, [page, uuid]);
+
+  const fetchNextPage = () => {
+    if (page >= totalPage) return;
+    setPage(prev => prev + 1);
+  };
+
+  return {
+    logs: data,
+    fetchNextPage,
+  };
+};

--- a/client/src/type/Document.type.ts
+++ b/client/src/type/Document.type.ts
@@ -17,11 +17,12 @@ export interface WriteDocumentContent {
 }
 
 export interface WikiDocumentLogSummary {
-  documentBytes: number;
-  generateTime: string;
-  logId: number;
+  id: number;
+  title: string;
   version: number;
   writer: string;
+  documentBytes: number;
+  generateTime: string;
 }
 
 export interface WikiDocumentLogDetail {


### PR DESCRIPTION
## issue

- close #93 

## 구현 설계

편집 로그를 불러오는 API가 단순 전체 리스트를 응답하는 방식에서 페이지네이션의 형태로 응답하도록 변경됐습니다.
매 번 전체 로그 목록을 불러오는 것에 대한 부담을 덜기 위함이라고 생각이 들었습니다. 그래서 이전에는 전체 페이지를 한 번에 렌더링했지만 이를 반영해서 페이지네이션 응답을 활용해 무한스크롤을 사용해서 데이터를 보여주면 좋겠다는 생각이 들었습니다.

이를 구현하면서 고민점이 있었습니다. 현재 로그 목록 조회 페이지는 서버에서 실행되는 `서버 컴포넌트`입니다.
그러나 무한스크롤을 도입하려면 Scroll 이벤트나 Intersection Observer를 사용해서 마지막 항목을 관측하고 다음 항목을 불러와서 리스트에 붙이는 기능을 추가해야 합니다. 이는 서버 컴포넌트가 아닌 클라이언트 컴포넌트에서 실행되어야 합니다.

이를 해결할 수 있는 방법으로 두 가지 방식을 고민했습니다.

1. 전부 클라이언트 컴포넌트로 처리한다.
2. 첫 페이지는 서버에서 만들고 나머지를 클라이언트에서 처리한다.

고민 결과 2번째 방식으로 구현하기로 결정했습니다. 서버에서 첫 페이지를 빠르게 만들어두고 다음 요청부터 만들어놓은 템플릿을 활용해서 빠르게 응답이 되도록 ISR이 적용되어있는데 이 장점을 활용하면서 나머지 페이지 응답을 뒤에 붙이도록 구현하는 것이 더 좋다고 생각했기 때문입니다.

그래서 첫 페이지는 서버 컴포넌트가 응답해서 페이지를 만들고 그 이후에 유저가 페이지 최하단으로 스크롤하면 다음 페이지를 불러와 붙이도록 구현했습니다.

## 구현 결과

### 서버에서 첫 페이지 결과와 총 페이지를 불러와 렌더링

먼저 페이지 컴포넌트(서버 컴포넌트)에서 데이터를 불러옵니다.
그리고 리스트를 출력하는 컴포넌트에 prop으로 페이지네이션 요청의 응답인 data와 totalPage를 넘겨줍니다.

```tsx
const response = await getDocumentLogsByUUIDServer(uuid);
<LogList key={uuid} uuid={uuid} initialData={response.data} totalPage={response.totalPage} />
```

### 클라이언트에서 다음 페이지를 불러오는 기능 구현

첫 페이지 데이터와 총 페이지를 서버에서 먼저 가져와서 prop으로 넘겨주었고, 이 데이터를 바탕으로 클라이언트에서 다음 페이지를 요청해야 합니다.

useGetDocumentLogs hook을 보면 현재 페이지와 데이터 두 가지 상태를 관리합니다.

```ts
const [page, setPage] = useState(0);
const [data, setData] = useState<WikiDocumentLogSummary[]>(initialData);
```

초기 페이지 상태는 0으로 서버에서 불러온 페이지 번호가 초기 상태입니다. 초기 데이터 상태도 서버에서 불러온 초기 상태를 넣어줍니다.

그리고 useEffect를 사용해서 page가 바뀔 때 다음 페이지를 불러오도록 fetch 기능을 넣었습니다.
이 때 page 상태가 0일 경우 (서버 컴포넌트에서 불러온 데이터만 있을 경우) fetch를 발생시키면 안 되므로 page가 0보다 클 때만 fetch를 하도록 조건문을 넣었습니다. 

```ts
  useEffect(() => {
    const fetchData = async () => {
      const response = ~~~;
      setData(prev => [...prev, ...response.data]);
    };

    if (page > 0) {
      fetchData();
    }
  }, [page, uuid]);
```

그리고 fetchNextPage는 페이지를 넘기는 함수입니다. 초기에 서버에서 받은 총 페이지 수와 현재 페이지를 비교해서 총 페이지 수까지 페이지 상태가 도달했다면 더 이상 페이지를 올리지 않아서 다음 페이지 요청을 일으키지 않도록 했습니다.

```ts
  const fetchNextPage = () => {
    if (page >= totalPage) return;
    setPage(prev => prev + 1);
  };
```

이 hook은 외부에서 fetchNextPage를 호출하면 다음 페이지 정보를 불러와 data 상태에 이어 붙이는 기능을 합니다. 
그러면 이제 fetchNextPage를 호출해주는 기능을 만들어야 합니다.

### InfinityScrollObserver 컴포넌트 구현

무한스크롤을 구현할 때 두 가지 방식을 고려합니다.

1. scroll 이벤트를 활용해서 다음 페이지 호출
2. Intersection Observer를 사용해서 페이지의 마지막이 관측될 때 다음 페이지 호출

저는 Intersection Observer를 사용하는 방식을 선택했습니다.
scroll 이벤트를 활용하게 되면 사용자가 스크롤 할 때마다 이벤트 리스너의 콜백이 실행되기 때문에 브라우저에 부담을 줄 수 있습니다.
반면 Intersection Observer를 활용하면 Observer 하나를 실행해서 특정 포인트가 관측될 때 콜백을 한 번 실행하기 때문에 브라우저의 부담을 덜 수 있는 방법이라고 생각했기 때문입니다.

이를 외부에서 쉽게 이를 사용할 수 있도록 유틸 컴포넌트 형식으로 만들었습니다.
유틸 컴포넌트 내부에 사용자가 관측할 div와 targetRef, Observer를 모두 관리해서 사용자 화면에 내부 div가 관측될 때 특정 콜백을 실행할 수 있도록 했으며, 외부에서 관측됐을 때 실행할 callback만 넣어주면 바로 실행할 수 있도록 설계했습니다.

그래서 사용처에서는 리스트가 렌더링되는 컴포넌트 밑에 InfiniteScrollObserver를 추가해서 콜백만 넣어주면 Intersection Observer를 바로 사용할 수 있도록 했습니다. 

```tsx
    <div className="flex flex-col gap-4">
      {logs?.map(log => <LogContent key={log.id} uuid={uuid} summary={log} />)}
      <InfiniteScrollObserver key={uuid} callback={fetchNextPage} />
    </div>
```

## 결과

실제로 서버에서 10개의 데이터를 먼저 만들어준 뒤에 그 다음 페이지부터는 클라이언트에서 호출하는 모습을 확인할 수 있습니다.

첫 페이지는 서버에서 만들어서 응답
![image](https://github.com/user-attachments/assets/1c0d11c8-b8e2-4749-be0a-7a5a59e51972)

그 다음부터 클라이언트에서 실행
![image](https://github.com/user-attachments/assets/63b221d0-982a-44ed-bf13-f7d22d33437d)
