### PR TITLE
문서 편집 로그 상세 불러오는 기능 복원

### DIFF
--- a/client/src/app/wiki/[uuid]/log/[logId]/page.tsx
+++ b/client/src/app/wiki/[uuid]/log/[logId]/page.tsx
@@ -1,4 +1,4 @@
-import {getSpecificDocumentLog} from '@apis/server/document';
+import {getSpecificDocumentLogServer} from '@apis/server/document';
 import DocumentContents from '@components/document/layout/DocumentContents';
 import DocumentFooter from '@components/document/layout/DocumentFooter';
 import DocumentHeader from '@components/document/layout/DocumentHeader';
@@ -24,7 +24,7 @@ export async function generateMetadata({params}: UUIDLogParams): Promise<Metadat
 
 const Page = async ({params}: UUIDLogParams) => {
   const {uuid, logId} = await params;
-  const document = await getSpecificDocumentLog(Number(logId));
+  const document = await getSpecificDocumentLogServer(Number(logId));
   const contents = await markdownToHtml(document.contents);
 
   return (


### PR DESCRIPTION
## issue

- close #97 

## 구현 사항

### import 함수 이름 변경

이전 이슈에서 getSpecificDocumentLogServer로 함수 이름을 변경했습니다. 이를 반영하지 않아 문제가 생겼던 것이라서 이를 반영해줬습니다.

import {getSpecificDocumentLogServer} from '@apis/server/document';


## 🫡 참고사항
