### PR TITLE
문서 생성 시 중복 문서를 감지하는 기능 복원

### DIFF
--- a/client/src/apis/client/document.ts
+++ b/client/src/apis/client/document.ts
@@ -78,3 +78,12 @@ export const putDocumentClient = async (document: PostDocumentContent) => {
 
   return editDocument;
 };
+
+export const getDocumentTitleListClient = async () => {
+  const response = await requestGetClient<string[]>({
+    baseUrl: process.env.NEXT_PUBLIC_FRONTEND_SERVER_BASE_URL,
+    endpoint: '/api/get-document-title-list',
+  });
+
+  return response;
+};

--- a/client/src/app/api/get-document-title-list/route.ts
+++ b/client/src/app/api/get-document-title-list/route.ts
@@ -1,0 +1,20 @@
+'use server';
+
+import {getDocumentsMap} from '@utils/documentCache';
+import {NextResponse} from 'next/server';
+
+export const GET = async () => {
+  const documentMap = await getDocumentsMap();
+  const titles = [...documentMap].map(([, value]) => value.title);
+
+  const response = {
+    data: titles,
+    code: 'SUCCESS',
+  };
+
+  try {
+    return NextResponse.json(response, {status: 200});
+  } catch (error) {
+    return NextResponse.json({error}, {status: 500});
+  }
+};

--- a/client/src/components/document/Write/TitleInputField.tsx
+++ b/client/src/components/document/Write/TitleInputField.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Input from '@components/common/Input';
-import useSearchDocumentByQuery from '@hooks/fetch/useSearchDocumentByQuery';
+import {useGetDocumentTitleList} from '@hooks/fetch/useGetDocumentTitleList';
 import {useDocument} from '@store/document';
 import {usePathname} from 'next/navigation';
 
@@ -23,7 +23,7 @@ const TitleInput = () => {
   const onChange = useDocument(action => action.onChange);
   const onBlur = useDocument(action => action.onBlur);
 
-  const {titles} = useSearchDocumentByQuery(title);
+  const {titles} = useGetDocumentTitleList();
 
   return (
     <Input
@@ -33,7 +33,7 @@ const TitleInput = () => {
       handleChangeInput={event => onChange(event.target.value, 'title')}
       maxLength={12}
       disabled={pathname.includes('edit')}
-      onBlur={event => onBlur(event.target.value, 'title', titles)}
+      onBlur={event => onBlur(event.target.value, 'title', titles ?? [])}
       invalid={error !== null}
     />
   );

--- a/client/src/hooks/fetch/useGetDocumentTitleList.ts
+++ b/client/src/hooks/fetch/useGetDocumentTitleList.ts
@@ -1,0 +1,10 @@
+import {getDocumentTitleListClient} from '@apis/client/document';
+import {useFetch} from '@hooks/useFetch';
+
+export const useGetDocumentTitleList = () => {
+  const {data} = useFetch<string[]>(getDocumentTitleListClient);
+
+  return {
+    titles: data,
+  };
+};


### PR DESCRIPTION
## issue

- close #99 

## 구현 사항

### API 변동으로 현재 존재하는 제목의 리스트를 얻을 수 있는 방법 필요

원래는 document/search api를 요청할 때 '' 빈 문자열을 요청하면 전체 리스트가 응답 됐습니다. 그러나 백엔드에서 이를 수정해서 빈 문자열을 요청할 때 빈 리스트를 응답하도록 변경되었습니다. 그래서 전체 문서의 제목을 알 수 있는 다른 방법을 강구해야 했습니다.

### 서버의 전체 문서 캐시 데이터 활용

마침 서버에서 전체 문서 정보를 빌드할 때 저장해서 사용하고 있던 것을 떠올렸습니다.
이 정보를 활용하면 충분히 구현할 수 있겠다는 생각이 들었습니다. 그래서 서버의 데이터를 조회할 수 있는 api route를 생성했습니다.

서버에 저장되어있는 데이터를 가져와서 title들을 추려서 응답으로 보내주면 클라이언트에서 리스트를 받아와 사용할 수 있습니다.

```ts
export const GET = async () => {
  const documentMap = await getDocumentsMap();
  const titles = [...documentMap].map(([, value]) => value.title);

  const response = {
    data: titles,
    code: 'SUCCESS',
  };

  try {
    return NextResponse.json(response, {status: 200});
  } catch (error) {
    return NextResponse.json({error}, {status: 500});
  }
};
```


## 🫡 참고사항

UUID 변경 작업이 완료되었습니다.
이제 백엔드가 운영 서버에 배포되면 그에 맞추어 배포 작업을 하면 UUID 이전 작업이 드디어 마무리 될 것 같습니다.
