### PR TITLE
존재하지 않는 문서 url에서 500 에러 발생하는 문제 해결

### DIFF
--- a/client/src/app/wiki/[uuid]/page.tsx
+++ b/client/src/app/wiki/[uuid]/page.tsx
@@ -18,17 +18,30 @@ export async function generateStaticParams() {
 
 export async function generateMetadata({params}: UUIDParams): Promise<Metadata> {
   const {uuid} = await params;
-  const documentTitle = await getDocumentTitleUsingUUID(uuid);
 
-  return {
-    title: documentTitle,
-    description: `${documentTitle}에 대한 정보(논란)를 확인하세요.`,
-    openGraph: {
-      title: `크루위키 ${documentTitle}의 문서`,
+  try {
+    const documentTitle = await getDocumentTitleUsingUUID(uuid);
+
+    return {
+      title: documentTitle,
       description: `${documentTitle}에 대한 정보(논란)를 확인하세요.`,
-      images: `${process.env.NEXT_PUBLIC_CDN_DOMAIN}/images/daemoon.png`,
-    },
-  };
+      openGraph: {
+        title: `크루위키 ${documentTitle}의 문서`,
+        description: `${documentTitle}에 대한 정보(논란)를 확인하세요.`,
+        images: `${process.env.NEXT_PUBLIC_CDN_DOMAIN}/images/daemoon.png`,
+      },
+    };
+  } catch (error) {
+    return {
+      title: '크루위키',
+      description: '존재하지 않는 문서입니다.',
+      openGraph: {
+        title: '크루위키',
+        description: '존재하지 않는 문서입니다.',
+        images: `${process.env.NEXT_PUBLIC_CDN_DOMAIN}/images/daemoon.png`,
+      },
+    };
+  }
 }
 
 // next.js v15부터 params를 받기 위해 await를 사용해야 함

--- a/client/src/utils/getDocumentUsingUUIDInCache.ts
+++ b/client/src/utils/getDocumentUsingUUIDInCache.ts
@@ -15,9 +15,5 @@ export const getDocumentUsingUUID = async (uuid: string) => {
   const documentMap = await getDocumentsMap();
   const document = documentMap.get(uuid);
 
-  if (!document) {
-    throw new Error(`캐시에 ${uuid}를 가진 문서가 없습니다.`);
-  }
-
-  return document;
+  return document || null;
 };


### PR DESCRIPTION
## issue

- close #105 

## 구현 사항

[v3.0.0](https://github.com/Crew-Wiki/crew-wiki-next/pull/101) 이후 https://www.crew-wiki.site/wiki/d 등, 
존재하지 않는 문서의 페이지에 진입하려고 하면  500 Internal Server Error 에러가 발생하는 문제가 있었습니다. 
다만 개발 환경에서는 정상적으로 404 페이지가 표시되고 있었습니다.
프로덕션 환경에서도 정상적인 위키 페이지에 `존재하지 않는 문서에요.` 라는 안내 문구가 노출되도록 개선했습니다.

### 영상

- 1~5초 : 배포된 사이트
- 6초~ : 개발 환경

https://github.com/user-attachments/assets/b47a0c8d-7e1d-482e-8f3f-b8fcfa35178e


### 개선 내용

1. `generateMetadata`에 try-catch 추가하여 에러 처리

- 에러 발생 시 기본 메타데이터 반환

`generateMetadata`에서 문제가 발생하고 있었습니다.

```
// 문서가 없으면 Error throw
const documentTitle = await getDocumentTitleUsingUUID(uuid);
// → Error: "캐시에 {uuid}를 가진 문서가 없습니다."
```

이 에러는 catch되지 않아 Next.js 프레임워크 레벨로 전파되어 500 에러가 발생했습니다.


`src/app/wiki/[uuid]/page.tsx` 컴포넌트에서 다음과 같이 구현되어 있습니다. 

```
if (!document) {
    notFound(); // 404 페이지로 이동
}
```

하지만 `generateMetadata`의 에러로 인해서 이 코드까지 도달하지 못했던 문제가 있었습니다.

2. `getDocumentUsingUUID` 함수 수정

- Error throw 대신 null 반환
- Page 컴포넌트의 null 체크 로직과 일관성 유지


`getDocumentUsingUUID`에서 Error throw 대신 null을 반환하도록 개선했습니다.
이렇게 개선함으로써 정상적으로 404 페이지가 표시됩니다. 

 ### 확인 사항

  - [x] 존재하지 않는 문서 URL 접근 시 404 페이지 정상 표시
  - [x] 메타데이터 기본값 정상 적용
  - [x] 기존 정상 동작 영향 없음

## 중점적으로 리뷰받고 싶은 부분(선택)

어떤 부분을 중점으로 리뷰했으면 좋겠는지 작성해주세요.

## 논의하고 싶은 부분(선택)

논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항
