### PR TITLE
대문 리다이렉션 처리

### DIFF
--- a/client/next.config.ts
+++ b/client/next.config.ts
@@ -25,6 +25,11 @@ const nextConfig: NextConfig = {
       destination: `${URLS.wiki}/${URLS.daemoon}`,
       permanent: false,
     },
+    {
+      source: `${URLS.wiki}/%EB%8C%80%EB%AC%B8`,
+      destination: `${URLS.wiki}/${URLS.daemoon}`,
+      permanent: true,
+    },
   ],
 };
 


### PR DESCRIPTION
## issue

- close #104 

## 구현 사항

### `/wiki/대문` -> `/wiki/[대문uuid]` 로 리다이렉트 설정

#### 배경
- url에 문서의 제목 대신 각 문서의 고유한 uuid를 사용하여 자원을 식별하게 되었습니다.
- 따라서 SEO 설정 변경과 즐겨찾기로 접속하던 사용자들을 변경된 주소로 리다이렉션하는 작업이 요구되었습니다.

#### 구현 설명
- Nextjs는 리다이렉트 시 307, 308 상태 코드를 사용합니다.
- next.config.ts에서 리다이렉트 설정을 할 때 permanent 설정을 할 수 있는데요, 이 값을 false로 설정 시 307 (Temporary Redirect), true로 설정 시 308 (Permanent Redirect) 상태 코드를 갖게 됩니다.
- 논의를 바탕으로 기존 url인 `/wiki/대문`은 더 이상 사용하지 않게 되었고, SEO 점수가 분산되는 것을 막기 위해 permanent 속성을 `true`로 설정했습니다!

|동작 영상|
|---|
|<video src="https://github.com/user-attachments/assets/a946be8a-abf4-43ad-a6f8-1462df33b5a9"/>|


#### Permanent 추가 설명

- false로 설정 시 : 검색엔진은 리다이렉트 시킬 대상이 되는 주소를 '나중에 원본 url로 다시 돌아올 수 있다'고 판단해서 기존 주소도 인덱싱을 유지해요. 따라서 SEO 점수가 기존 주소와 새 주소로 분산돼요.
- true로 설정 시 : 검색엔진은 기존 주소를 더 이상 사용하지 않는다고 판단하고 기존 주소 인덱싱은 해제해요. 따라서 시간이 지나면서 SEO 점수가 새로운 주소로만 누적되고, 기존 주소는 검색 결과에서 사라지게 돼요.

#### 기대 효과
- '크루위키'를 구글에 검색 시 기존 'https://www.crew-wiki.site/' 주소로 연결되는 것은 유지돼요.
![image](https://github.com/user-attachments/assets/91dc64c1-f2b0-43b5-8fb9-c23c0fa405b2)
- 반면 '크루위키 대문'을 구글에 검색하면 '/wiki/대문' 대신 '/wiki/[대문uuid]'로 대체돼요.
![image](https://github.com/user-attachments/assets/843ffc2c-7feb-44a2-ae5e-18a1765f0fad)
- 즐겨찾기에 /wiki/대문을 저장해놓았을 때, 이 링크를 타고 접속하면 /wiki/[대문uuid]로 리다이렉트돼요.

## 🫡 참고사항
- 논의 스레드 : 크루위키 디스코드 > FE > 잡담 