### PR TITLE
이미지 불러오기 실패하는 문서 버그 해결

### DIFF
--- a/client/src/utils/processImageHtml.ts
+++ b/client/src/utils/processImageHtml.ts
@@ -10,8 +10,7 @@ export function processImageHtml(html: string): string {
       const pathParts = url.pathname.split('/');
       const filename = pathParts[pathParts.length - 1];
 
-      const hasExtension = /\.(jpeg|jpg|png|gif|webp)$/i.test(filename);
-      const processedFilename = hasExtension ? filename : `${filename.replace(/\.[^/.]+$/, '')}.jpeg`;
+      const processedFilename = filename.replace(/\.[^/.]+$/, '') + '.jpeg';
 
       pathParts[pathParts.length - 1] = processedFilename;
       url.pathname = pathParts.join('/');


### PR DESCRIPTION
## issue

- close #122 

## 구현 사항

### 확장자 포함 여부 관계없이 전부 JPEG로 확장자를 바꾸도록 설정

기존엔 이미지 파일 이름에 .jpg, .png 등 확장자가 있는 경우, 확장자를 .jpeg로 변경하지 않고 그대로 사용했습니다.
확장자가 없는 경우에만 .jpeg를 추가해 주었기 때문에, S3에 저장된 .jpeg 형식의 이미지와 일치하지 않아 이미지가 표시되지 않는 문제가 있었습니다.

그래서 확장자가 있든 없든 모두 jpeg로 변경하도록 하여 이미지가 보이도록 했습니다.

## 결과

제 문서를 테스트로 본 결과 잘 나오네요. 이전에 안 뜨던 페이지들도 확인했는데 잘 나옵니다.

<img width="470" height="752" alt="image" src="https://github.com/user-attachments/assets/b4129caf-b221-46e3-9b99-5f2cd3a177c8" />
