### PR TITLE
dev 서버 CD 스크립트 작성

### DIFF
--- a/.github/workflows/frontend-dev-deploy.yml
+++ b/.github/workflows/frontend-dev-deploy.yml
@@ -23,4 +23,4 @@ jobs:
             git pull origin develop
             yarn install
             yarn build
-            pm2 restart ecosystem.config.js --update-env
+            pm2 restart ecosystem.config.js --env development --update-env

--- a/.github/workflows/frontend-prod-deploy.yml
+++ b/.github/workflows/frontend-prod-deploy.yml
@@ -26,4 +26,4 @@ jobs:
             git pull origin main
             yarn install
             yarn build
-            pm2 restart ecosystem.config.js --update-env
+            pm2 restart ecosystem.config.js --env production --update-env

--- a/client/ecosystem.config.js
+++ b/client/ecosystem.config.js
@@ -11,6 +11,13 @@ module.exports = {
       env: {
         NODE_ENV: 'production',
       },
+
+      env_development: {
+        NODE_ENV: 'development',
+      },
+      env_production: {
+        NODE_ENV: 'production',
+      },
     },
   ],
 };


### PR DESCRIPTION
## issue

- close #131 

## 구현 사항

오늘 frontend dev 서버를 구축했고, 이 역시 CD 스크립트가 있으면 좋을 것 같아 작성했습니다.
이전 prod CD와 비슷하며 큰 차이점은 액션 실행방법입니다.

이 액션은 직접 Github에서 Actions 탭에 들어가서 run workflow를 실행해야 동작합니다.
그렇지 않으면 dev에 머지될 때마다 cd가 동작해서 서버에 부담을 줄 수 있다고 생각해요.
dev에 머지가 다 완료됐다면 그 때 Actions 탭에 들어가서 액션을 실행시키면 동작할 겁니다.

아마 prod랑 환경은 비슷하니 아마 될 겁니다ㅎㅎㅎ

## 🫡 참고사항
