### PR TITLE
모달 컴포넌트 구현

### DIFF
--- a/client/src/app/layout.tsx
+++ b/client/src/app/layout.tsx
@@ -48,7 +48,10 @@ export default function RootLayout({
       className={`${pretendard.variable} scroll-pt-[50vh] scroll-smooth`}
       style={{backgroundColor: '#f3f4f6'}}
     >
-      <body className={bm.variable}>{children}</body>
+      <body className={bm.variable}>
+        {children}
+        <div id="modal-root"></div>
+      </body>
     </html>
   );
 }

--- a/client/src/app/wiki/statistics/page.tsx
+++ b/client/src/app/wiki/statistics/page.tsx
@@ -1,9 +1,44 @@
+'use client';
+
+import Button from '@components/common/Button';
+import {Modal} from '@components/common/Modal/Modal';
+import {useModal} from '@components/common/Modal/useModal';
+
 const Page = () => {
+  const modal = useModal<boolean>(
+    <Modal>
+      <h1>안녕</h1>
+      <div className="flex flex-row gap-2">
+        <Button size="xs" style="primary" onClick={() => modal.close(true)}>
+          확인
+        </Button>
+        <Button size="xs" style="tertiary" onClick={() => modal.close(false)}>
+          취소
+        </Button>
+      </div>
+    </Modal>,
+    {
+      closeOnClickDimmedLayer: true,
+      onClose: () => {
+        console.log('모달 종료');
+      },
+    },
+  );
+
+  const handleOpen = async () => {
+    const response = await modal.open();
+    console.log(response);
+  };
+
   return (
     <section className="flex w-full flex-col items-center gap-6">
       <div className="flex h-fit min-h-[864px] w-full flex-col gap-6 rounded-xl border border-solid border-primary-100 bg-white p-8 max-md:gap-2 max-md:p-4">
         <h1 className="font-bm text-2xl text-grayscale-800">테스트</h1>
+        <Button style="secondary" size="m" onClick={handleOpen}>
+          모달 열기
+        </Button>
       </div>
+      {modal.component}
     </section>
   );
 };

--- a/client/src/components/common/Modal/DimmedLayer.tsx
+++ b/client/src/components/common/Modal/DimmedLayer.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import {MouseEvent, PropsWithChildren} from 'react';
+
+type DimmedLayerProps = PropsWithChildren<{
+  opacity?: number;
+  onClick: (event: MouseEvent) => void;
+}>;
+
+export const DimmedLayer = ({children, opacity = 0.32, onClick}: DimmedLayerProps) => {
+  return (
+    <div
+      style={{backgroundColor: `rgba(0, 0, 0, ${opacity})`}}
+      className="fixed bottom-0 left-0 right-0 top-0 z-50 flex items-center justify-center"
+      onClick={onClick}
+    >
+      {children}
+    </div>
+  );
+};

--- a/client/src/components/common/Modal/HideScroll.tsx
+++ b/client/src/components/common/Modal/HideScroll.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import {PropsWithChildren, useEffect} from 'react';
+
+export const HideScroll = ({children}: PropsWithChildren) => {
+  useEffect(() => {
+    document.body.style.overflow = 'hidden';
+
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, []);
+
+  return <>{children}</>;
+};

--- a/client/src/components/common/Modal/ManualPromise.ts
+++ b/client/src/components/common/Modal/ManualPromise.ts
@@ -1,0 +1,12 @@
+export class ManualPromise<T> {
+  promise: Promise<T>;
+  resolve!: (value: T | PromiseLike<T>) => void;
+  reject!: (reason?: unknown) => void;
+
+  constructor() {
+    this.promise = new Promise<T>((res, rej) => {
+      this.resolve = res;
+      this.reject = rej;
+    });
+  }
+}

--- a/client/src/components/common/Modal/Modal.tsx
+++ b/client/src/components/common/Modal/Modal.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import {PropsWithChildren} from 'react';
+
+type ModalProps = PropsWithChildren;
+
+export const Modal = ({children}: ModalProps) => {
+  return (
+    <div className="flex flex-col rounded-xl border border-solid border-primary-100 bg-white px-6 py-8">{children}</div>
+  );
+};

--- a/client/src/components/common/Modal/Overlay.tsx
+++ b/client/src/components/common/Modal/Overlay.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import {PropsWithChildren, useEffect} from 'react';
+import {createPortal} from 'react-dom';
+
+type OverlayProps = PropsWithChildren;
+
+export const Overlay = ({children}: OverlayProps) => {
+  const target = document.getElementById('modal-root');
+
+  useEffect(() => {
+    document.body.classList.add('modal-open');
+
+    return () => {
+      document.body.classList.remove('modal-open');
+    };
+  }, []);
+
+  if (!target) {
+    return null;
+  }
+
+  return createPortal(children, target);
+};

--- a/client/src/components/common/Modal/useManualPromise.ts
+++ b/client/src/components/common/Modal/useManualPromise.ts
@@ -1,0 +1,43 @@
+'use client';
+
+import {useCallback, useRef} from 'react';
+import {ManualPromise} from './ManualPromise';
+
+export const useManualPromise = <T = void>() => {
+  const promiseRef = useRef<ManualPromise<T> | null>(null);
+
+  const cancelPreviousPromise = useCallback(() => {
+    if (promiseRef.current) {
+      promiseRef.current.reject?.(new Error('이전 promise가 취소되었습니다.'));
+      promiseRef.current = null;
+    }
+  }, []);
+
+  const createNewPromise = useCallback(() => {
+    promiseRef.current = new ManualPromise<T>();
+    return promiseRef.current.promise;
+  }, []);
+
+  const getPromise = useCallback(() => {
+    cancelPreviousPromise();
+    return createNewPromise();
+  }, [cancelPreviousPromise, createNewPromise]);
+
+  const resolve = useCallback((value: T) => {
+    if (promiseRef.current) {
+      promiseRef.current.resolve?.(value);
+    }
+  }, []);
+
+  const reject = useCallback((reason?: Error) => {
+    if (promiseRef.current) {
+      promiseRef.current.reject?.(reason);
+    }
+  }, []);
+
+  return {
+    getPromise,
+    resolve,
+    reject,
+  };
+};

--- a/client/src/components/common/Modal/useModal.tsx
+++ b/client/src/components/common/Modal/useModal.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import {useCallback, useEffect, useState, type ReactNode, MouseEvent} from 'react';
+import {useManualPromise} from './useManualPromise';
+import {Overlay} from './Overlay';
+import {HideScroll} from './HideScroll';
+import {DimmedLayer} from './DimmedLayer';
+
+export type ModalOption = {
+  closeOnClickDimmedLayer?: boolean;
+  onClose?: VoidFunction;
+};
+
+export const useModal = <T,>(modal: ReactNode, {closeOnClickDimmedLayer = true, onClose}: ModalOption = {}) => {
+  const [showModal, setShowModal] = useState(false);
+  const {getPromise, resolve, reject} = useManualPromise<T | undefined>();
+
+  const open = useCallback(async () => {
+    setShowModal(true);
+    return getPromise();
+  }, [getPromise]);
+
+  const close = useCallback(
+    (value?: T) => {
+      resolve(value);
+      onClose?.();
+      setShowModal(false);
+    },
+    [onClose, resolve],
+  );
+
+  const closeWithReject = useCallback(
+    (message?: string) => {
+      reject(new Error(message));
+      onClose?.();
+      setShowModal(false);
+    },
+    [onClose, reject],
+  );
+
+  useEffect(() => {
+    return () => close(undefined);
+  }, [close]);
+
+  const component = showModal ? (
+    <Overlay>
+      <HideScroll>
+        <DimmedLayer
+          onClick={(event: MouseEvent) => {
+            event.stopPropagation();
+            if (closeOnClickDimmedLayer && event.target === event.currentTarget) {
+              close(undefined);
+            }
+          }}
+        >
+          {modal}
+        </DimmedLayer>
+      </HideScroll>
+    </Overlay>
+  ) : null;
+
+  return {
+    open,
+    close,
+    closeWithReject,
+    component,
+    isOpened: showModal,
+  } as const;
+};

--- a/client/src/components/common/Modal/useModal.tsx
+++ b/client/src/components/common/Modal/useModal.tsx
@@ -39,8 +39,8 @@ export const useModal = <T,>(modal: ReactNode, {closeOnClickDimmedLayer = true, 
   );
 
   useEffect(() => {
-    return () => close(undefined);
-  }, [close]);
+    return () => reject(new Error('Modal unmounted'));
+  }, [reject]);
 
   const component = showModal ? (
     <Overlay>


### PR DESCRIPTION
## issue

- close #134 

## 구현 사항

### 모달 컴포넌트 구현

사용하기 쉽게 모달을 사용할 수 있도록 useModal 훅과 Modal 컴포넌트를 구현했습니다.
모달의 열림 닫힘 상태는 useModal이 책임지며 별도로 외부에서 state를 만들어 모달을 조건부 렌더링 할 필요가 없습니다.
Modal 컴포넌트는 모달 스타일을 정의한 컴포넌트입니다.

기능은 useModal에 전부 선언되어있고, 필요한 스타일은 Modal 컴포넌트를 불러 사용하면 됩니다.

useModal의 첫 번째 인자로 띄우고 싶은 모달 컴포넌트를 넣어줍니다.
옵션으로 두 가지를 받으며, 모달의 dimmed layer를 클릭했을 때 꺼짐 여부, 모달이 닫힐 때 실행되는 콜백함수를 추가로 넣어줄 수 있습니다.

```ts
export type ModalOption = {
  closeOnClickDimmedLayer?: boolean;
  onClose?: VoidFunction;
};

const modal = useModal<boolean>(
  <Modal>
    <h1>안녕</h1>
    <div className="flex flex-row gap-2">
      <Button size="xs" style="primary" onClick={() => modal.close(true)}>
        확인
      </Button>
      <Button size="xs" style="tertiary" onClick={() => modal.close(false)}>
        취소
      </Button>
    </div>
  </Modal>,
);
```

### useModal 자세히

useModal은 총 다섯가지를 제공해줍니다.

- open: 모달을 여는 메서드
- close: 모달을 닫는 메서드 (resolve 호출)
- closeWithReject: 모달을 닫으면서 reject를 호출하는 메서드
- component: useModal 첫 번째 인자로 받은 모달 내부 컴포넌트
- isOpened: 모달의 열림 상태 (거의 사용할 일 없을 듯하지만 혹시나 해서)

useModal은 내부적으로 프로미스를 사용합니다.
모달이 열릴 때 프로미스를 생성하고 모달이 닫힐 때 resolve를 호출해서 모달의 결과를 기다린 후 다음 액션을 실행할 수 있습니다.
위의 예시에서 modal.close(true)를 호출해서 모달을 종료하면 response에는 true가 console로 찍히게 됩니다.

```tsx
const handleOpen = async () => {
  const response = await modal.open();
  console.log(response);
};
```

이렇게 설계한 이유는 모달을 열고 확인 버튼을 누를 때 api 호출이 일어날 일이 꽤 있을 것이라 생각했기 때문입니다.
저의 todo인 문서 충돌 기능도 그렇고, 이벤트 추가하기에도 확인을 누르면 추가 api가 호출되기 때문에 이렇게 관리하면 좋을 것 같아서 비동기를 활용해봤습니다.


### 구현 영상

https://github.com/user-attachments/assets/d7290c96-304e-473c-882a-d14cc56597ad



## 🫡 참고사항
