### PR TITLE
문서 충돌 기능 구현

### DIFF
--- a/client/src/apis/client/document.ts
+++ b/client/src/apis/client/document.ts
@@ -2,7 +2,7 @@
 
 import {ENDPOINT} from '@constants/endpoint';
 import {requestGetClient, requestPostClient, requestPutClient} from '@http/client';
-import {PostDocumentContent, WikiDocument, WikiDocumentLogSummary} from '@type/Document.type';
+import {LatestWikiDocument, PostDocumentContent, WikiDocument, WikiDocumentLogSummary} from '@type/Document.type';
 import {PaginationParams, PaginationResponse} from '@type/General.type';
 
 export const getDocumentByTitleClient = async (title: string) => {
@@ -15,7 +15,7 @@ export const getDocumentByTitleClient = async (title: string) => {
 };
 
 export const getDocumentByUUIDClient = async (uuid: string) => {
-  const response = await requestGetClient<WikiDocument>({
+  const response = await requestGetClient<LatestWikiDocument>({
     baseUrl: process.env.NEXT_PUBLIC_BACKEND_SERVER_BASE_URL,
     endpoint: ENDPOINT.getDocumentByUUID(uuid),
   });

--- a/client/src/app/wiki/[uuid]/edit/page.tsx
+++ b/client/src/app/wiki/[uuid]/edit/page.tsx
@@ -4,7 +4,7 @@ import PostHeader from '@components/document/Write/PostHeader';
 import TitleInputField from '@components/document/Write/TitleInputField';
 import TuiEditor from '@components/document/TuiEditor';
 import {useParams} from 'next/navigation';
-import {act, useEffect} from 'react';
+import {useEffect} from 'react';
 import {useDocument} from '@store/document';
 import {LatestWikiDocument} from '@type/Document.type';
 import {useGetLatestDocumentByUUID} from '@hooks/fetch/useGetLatestDocumentByUUID';

--- a/client/src/app/wiki/[uuid]/edit/page.tsx
+++ b/client/src/app/wiki/[uuid]/edit/page.tsx
@@ -4,18 +4,19 @@ import PostHeader from '@components/document/Write/PostHeader';
 import TitleInputField from '@components/document/Write/TitleInputField';
 import TuiEditor from '@components/document/TuiEditor';
 import {useParams} from 'next/navigation';
-import {useGetDocumentByUUID} from '@hooks/fetch/useGetDocumentByUUID';
-import {useEffect} from 'react';
+import {act, useEffect} from 'react';
 import {useDocument} from '@store/document';
-import {WikiDocument} from '@type/Document.type';
+import {LatestWikiDocument} from '@type/Document.type';
+import {useGetLatestDocumentByUUID} from '@hooks/fetch/useGetLatestDocumentByUUID';
 
 type EditPageProps = {
-  document: WikiDocument;
+  document: LatestWikiDocument;
 };
 
 const EditPage = ({document}: EditPageProps) => {
   const setInit = useDocument(action => action.setInit);
   const reset = useDocument(action => action.reset);
+  const onChange = useDocument(action => action.onChange);
 
   useEffect(() => {
     setInit(
@@ -25,6 +26,7 @@ const EditPage = ({document}: EditPageProps) => {
         contents: document.contents,
       },
       document.documentUUID,
+      document.latestVersion,
     );
 
     return () => reset();
@@ -34,14 +36,14 @@ const EditPage = ({document}: EditPageProps) => {
     <section className="flex h-fit w-full flex-col gap-6 rounded-xl border border-solid border-primary-100 bg-white p-8 max-[768px]:gap-3 max-[768px]:p-4">
       <PostHeader mode="edit" />
       <TitleInputField />
-      <TuiEditor initialValue={document.contents} />
+      <TuiEditor initialValue={document.contents} onChange={value => onChange(value, 'contents')} />
     </section>
   );
 };
 
 const Page = () => {
   const {uuid} = useParams();
-  const {document} = useGetDocumentByUUID(uuid as string); // 최신의 데이터를 불러와야하기 때문에 캐시 데이터 사용하지 않음.
+  const {document} = useGetLatestDocumentByUUID(uuid as string); // 최신의 데이터를 불러와야하기 때문에 캐시 데이터 사용하지 않음.
 
   return document && <EditPage document={document} />;
 };

--- a/client/src/app/wiki/post/page.tsx
+++ b/client/src/app/wiki/post/page.tsx
@@ -12,6 +12,7 @@ const Page = () => {
   const {saveMarkdown, initialValue} = usePostSaveMarkdown();
   const setInit = useDocument(action => action.setInit);
   const reset = useDocument(action => action.reset);
+  const onChange = useDocument(action => action.onChange);
 
   useEffect(() => {
     setInit(
@@ -30,7 +31,11 @@ const Page = () => {
     <section className="flex h-fit w-full flex-col gap-6 rounded-xl border border-solid border-primary-100 bg-white p-8 max-[768px]:gap-3 max-[768px]:p-4">
       <PostHeader mode="post" />
       <TitleInputField />
-      <TuiEditor initialValue={initialValue} saveMarkdown={saveMarkdown} />
+      <TuiEditor
+        initialValue={initialValue}
+        saveMarkdown={saveMarkdown}
+        onChange={value => onChange(value, 'contents')}
+      />
     </section>
   );
 };

--- a/client/src/components/document/TuiEditor/index.tsx
+++ b/client/src/components/document/TuiEditor/index.tsx
@@ -24,14 +24,14 @@ const toolbar = [
 type TuiEditorProps = {
   saveMarkdown?: (markdown: string) => void;
   initialValue: string;
+  onChange: (value: string) => void;
 };
 
-function TuiEditor({initialValue, saveMarkdown}: TuiEditorProps) {
+function TuiEditor({initialValue, saveMarkdown, onChange}: TuiEditorProps) {
   const isDesktop = typeof window !== 'undefined' ? window.innerWidth >= 768 : false;
   const editorRef = useRef<EditorType | null>(null);
   const uuid = useDocument(state => state.uuid);
 
-  const onChange = useDocument(action => action.onChange);
   const {uploadImageAndReplaceUrl} = useUploadImage(uuid);
 
   useEffect(() => {
@@ -62,7 +62,7 @@ function TuiEditor({initialValue, saveMarkdown}: TuiEditorProps) {
 
     const instance = editorRef.current.getInstance();
     const markdown = instance.getMarkdown();
-    onChange(markdown, 'contents');
+    onChange(markdown);
 
     if (saveMarkdown) {
       const saveMarkDownThrottle = makeThrottle(() => saveMarkdown(markdown), MARKDOWN_THROTTLE_TIME);

--- a/client/src/components/document/Write/PostHeader.tsx
+++ b/client/src/components/document/Write/PostHeader.tsx
@@ -8,41 +8,112 @@ import {getBytes} from '@utils/getBytes';
 import {usePostDocument} from '@hooks/mutation/usePostDocument';
 import {usePutDocument} from '@hooks/mutation/usePutDocument';
 import {PostDocumentContent} from '@type/Document.type';
-
-type ModeProps = {
-  mode: 'post' | 'edit';
-};
+import {useState} from 'react';
+import {getDocumentByUUIDClient} from '@apis/client/document';
+import {useConflictModal} from './useConflictModal';
+import {createConflictText} from '@utils/createConflictText';
+import {URLS} from '@constants/urls';
+import {ModeProps} from './type';
 
 const RequestButton = ({mode}: ModeProps) => {
   const uuid = useDocument(state => state.uuid);
   const values = useDocument(state => state.values);
   const errors = useDocument(state => state.errorMessages);
   const isImageUploadPending = useDocument(state => state.isImageUploadPending);
+  const originalVersion = useDocument(state => state.originalVersion);
+  const router = useRouter();
+
+  const [conflict, setConflict] = useState<{version: number; content: string}>({
+    version: -1,
+    content: '',
+  });
 
   const requiredFields: Array<Field> = ['title', 'writer', 'contents'];
   const canSubmit = requiredFields.every(field => values[field].trim() !== '' && errors[field] === null);
+
+  const handleResolve = async (resolvedContent: string) => {
+    try {
+      // 재충돌 방지
+      const newLatest = await getDocumentByUUIDClient(uuid);
+
+      // 충돌 시 새 버전과 새로 불러온 버전이 다르다면 다시 충돌상황
+      if (newLatest && conflict.version !== newLatest.latestVersion) {
+        conflictModal.closeWithReject();
+        alert('병합하는 동안 새로운 변경사항이 생겼습니다. 다시 충돌을 해결해주세요.');
+        const conflictText = createConflictText(newLatest.contents, resolvedContent);
+        setConflict({version: newLatest.latestVersion, content: conflictText});
+        conflictModal.open();
+        return;
+      }
+
+      await handleSubmit(resolvedContent);
+      conflictModal.close(true);
+    } catch (error) {
+      console.error(error);
+      alert('저장에 실패했습니다.');
+    }
+  };
+
+  const conflictModal = useConflictModal({
+    initialContent: conflict.content,
+    onResolve: handleResolve,
+  });
 
   const {postDocument, isPostPending} = usePostDocument();
   const {putDocument, isPutPending} = usePutDocument();
   const isPending = isPostPending || isPutPending || isImageUploadPending;
 
-  const onSubmit = async () => {
+  const handleConflictCheck = async () => {
+    try {
+      const latest = await getDocumentByUUIDClient(uuid);
+
+      if (latest && originalVersion !== latest.latestVersion) {
+        const conflictText = createConflictText(latest.contents, values.contents);
+        setConflict({version: latest.latestVersion, content: conflictText});
+        conflictModal.open();
+      } else {
+        await handleSubmit(values.contents);
+      }
+    } catch (error) {
+      console.error(error);
+      alert('최신 버전을 확인하는데 실패했습니다. 잠시 후 다시 시도해주세요.');
+    }
+  };
+
+  const handleSubmit = async (contents: string) => {
     const document: PostDocumentContent = {
       uuid,
       title: values.title,
-      contents: values.contents,
+      contents,
       writer: values.writer,
-      documentBytes: getBytes(values.contents),
+      documentBytes: getBytes(contents),
     };
 
-    if (mode === 'post') await postDocument(document);
-    if (mode === 'edit') await putDocument(document);
+    if (mode === 'post') {
+      postDocument(document);
+    } else {
+      putDocument(document);
+    }
+
+    router.push(`${URLS.wiki}/${uuid}`);
+    router.refresh();
+  };
+
+  const onSubmit = async () => {
+    if (mode === 'edit') {
+      await handleConflictCheck();
+    } else {
+      await handleSubmit(values.contents);
+    }
   };
 
   return (
-    <Button style="primary" size="xs" disabled={!canSubmit || isPending} onClick={onSubmit}>
-      작성완료
-    </Button>
+    <>
+      <Button style="primary" size="xs" disabled={!canSubmit || isPending} onClick={onSubmit}>
+        작성완료
+      </Button>
+      {conflictModal.component}
+    </>
   );
 };
 

--- a/client/src/components/document/Write/type.ts
+++ b/client/src/components/document/Write/type.ts
@@ -1,0 +1,3 @@
+export type ModeProps = {
+  mode: 'post' | 'edit';
+};

--- a/client/src/components/document/Write/useConflictModal.tsx
+++ b/client/src/components/document/Write/useConflictModal.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import Button from '@components/common/Button';
+import TuiEditor from '@components/document/TuiEditor';
+import {useEffect, useState} from 'react';
+import {Modal} from '@components/common/Modal/Modal';
+import {useModal} from '@components/common/Modal/useModal';
+
+interface ConflictModalProps {
+  initialContent: string;
+  onResolve: (resolvedContent: string) => void;
+}
+
+export const useConflictModal = ({initialContent, onResolve}: ConflictModalProps) => {
+  const [content, setContent] = useState('');
+  const [isResolved, setIsResolved] = useState(false);
+
+  useEffect(() => {
+    setContent(initialContent);
+  }, [initialContent]);
+
+  useEffect(() => {
+    const hasConflictMarkers = /<<<<<|──────────────/.test(content);
+    setIsResolved(!hasConflictMarkers);
+  }, [content]);
+
+  const handleResolve = () => {
+    onResolve(content);
+    modal.close();
+  };
+
+  const modal = useModal<boolean>(
+    <Modal>
+      <h2 className="mb-4 text-2xl font-bold">문서 충돌 해결</h2>
+      <p className="mb-4">다른 사용자가 문서를 수정했습니다. 아래 내용을 병합하여 저장해주세요.</p>
+      <div className="mb-4">
+        <TuiEditor initialValue={initialContent} onChange={setContent} />
+      </div>
+      <div className="flex justify-end gap-2">
+        <Button style="tertiary" size="m" onClick={() => modal.close()}>
+          취소
+        </Button>
+        <Button style="primary" size="m" onClick={handleResolve} disabled={!isResolved}>
+          충돌 해결 완료
+        </Button>
+      </div>
+    </Modal>,
+    {closeOnClickDimmedLayer: false},
+  );
+
+  return modal;
+};

--- a/client/src/hooks/fetch/useGetLatestDocumentByUUID.ts
+++ b/client/src/hooks/fetch/useGetLatestDocumentByUUID.ts
@@ -2,12 +2,12 @@
 
 import {getDocumentByUUIDClient} from '@apis/client/document';
 import {useFetch} from '@hooks/useFetch';
-import {WikiDocument} from '@type/Document.type';
+import {LatestWikiDocument} from '@type/Document.type';
 import {useCallback} from 'react';
 
-export const useGetDocumentByUUID = (uuid: string) => {
+export const useGetLatestDocumentByUUID = (uuid: string) => {
   const getData = useCallback(() => getDocumentByUUIDClient(uuid), [uuid]);
-  const {data} = useFetch<WikiDocument>(getData);
+  const {data} = useFetch<LatestWikiDocument>(getData);
 
   return {
     document: data,

--- a/client/src/store/document.ts
+++ b/client/src/store/document.ts
@@ -16,6 +16,7 @@ type State = {
   errorMessages: Record<Field, ErrorMessage>;
   uuid: string;
   isImageUploadPending: boolean;
+  originalVersion: number;
 };
 
 type Validators = {
@@ -24,7 +25,7 @@ type Validators = {
 };
 
 type Action = {
-  setInit: (initial: FieldType, uuid: string | null) => void;
+  setInit: (initial: FieldType, uuid: string | null, version?: number) => void;
   onChange: (value: string, field: Field) => void;
   onBlur: (value: string, field: Field, list?: string[]) => void;
   reset: () => void;
@@ -55,11 +56,12 @@ const initialValue: State = {
   },
   uuid: '',
   isImageUploadPending: false,
+  originalVersion: 0,
 };
 
 export const useDocument = create<State & Action>(set => ({
   ...initialValue,
-  setInit: (initial, uuid) => {
+  setInit: (initial, uuid, version) => {
     set({
       values: {
         title: initial.title,
@@ -72,6 +74,7 @@ export const useDocument = create<State & Action>(set => ({
         contents: null,
       },
       uuid: uuid ? uuid : crypto.randomUUID(),
+      originalVersion: version ? version : 0,
     });
   },
 

--- a/client/src/type/Document.type.ts
+++ b/client/src/type/Document.type.ts
@@ -9,6 +9,10 @@ export interface WikiDocument {
   generateTime: string;
 }
 
+export interface LatestWikiDocument extends WikiDocument {
+  latestVersion: number;
+}
+
 export interface WriteDocumentContent {
   title: string;
   contents: string;

--- a/client/src/utils/createConflictText.ts
+++ b/client/src/utils/createConflictText.ts
@@ -1,0 +1,53 @@
+const findFirstDiffIndex = (remoteLines: string[], localLines: string[]): number => {
+  let i = 0;
+  while (i < remoteLines.length && i < localLines.length && remoteLines[i] === localLines[i]) {
+    i++;
+  }
+  return i;
+};
+
+const findLastDiffIndex = (remoteLines: string[], localLines: string[]): {remoteIndex: number; localIndex: number} => {
+  let i = remoteLines.length - 1;
+  let j = localLines.length - 1;
+  while (i >= 0 && j >= 0 && remoteLines[i] === localLines[j]) {
+    i--;
+    j--;
+  }
+  return {remoteIndex: i, localIndex: j};
+};
+
+export const createConflictText = (remoteContent: string, localContent: string): string => {
+  if (remoteContent === localContent) {
+    return remoteContent;
+  }
+
+  const remoteLines = remoteContent.split('\n');
+  const localLines = localContent.split('\n');
+
+  const firstDiffIndex = findFirstDiffIndex(remoteLines, localLines);
+  const {remoteIndex: lastRemoteDiffIndex, localIndex: lastLocalDiffIndex} = findLastDiffIndex(remoteLines, localLines);
+
+  const commonPrefix = remoteLines.slice(0, firstDiffIndex).join('\n');
+  const commonSuffix = remoteLines.slice(lastRemoteDiffIndex + 1).join('\n');
+
+  const remoteDiff = remoteLines.slice(firstDiffIndex, lastRemoteDiffIndex + 1).join('\n');
+  const localDiff = localLines.slice(firstDiffIndex, lastLocalDiffIndex + 1).join('\n');
+
+  let conflictText = '';
+
+  if (commonPrefix) {
+    conflictText += `${commonPrefix}\n`;
+  }
+
+  conflictText += '<<<<< 최신 버전\n';
+  conflictText += `${remoteDiff}\n`;
+  conflictText += '──────────────\n';
+  conflictText += `${localDiff}\n`;
+  conflictText += '<<<<< 내 작업\n';
+
+  if (commonSuffix) {
+    conflictText += `${commonSuffix}\n`;
+  }
+
+  return conflictText.trim();
+};


### PR DESCRIPTION
## issue

- close #119 

## 구현 사항

문서 수정 시에 내가 수정하던 도중 다른 사람이 문서를 수정했을 때 덮어씌워지는 문제가 있었습니다.
이 문제를 개선하고자 문서 충돌 기능을 구현했습니다.

### 문서 충돌 판단 기준

문서 수정하기 페이지에 진입했을 때 서버에서 최신의 문서를 가져옵니다 (최신 버전을 기준으로 수정해야하므로)
이 때 현재 문서의 최신 버전 latestVersion을 가져오도록 기능이 추가되었습니다. 이를 사용해서 판단합니다.
사용자가 문서를 수정하고 버튼을 누를 때, 페이지 진입 시 가져왔던 버전과 버튼을 누를 시점의 버전이 다르다면 내가 수정하던 도중 다른 사람이 문서를 수정한 경우입니다.

이 때 충돌 모달을 띄워서 사용자에게 충돌을 직접 해결하도록 했습니다. 충돌 표시는 git과 유사하게 했습니다.
(크루위키를 사용하는 유저들은 모두 개발자임으로 git 충돌 해결하는 방법은 알겠죠?ㅋㅋㅋㅋㅋㅋ)

### 문서 충돌 해결방법
git merge나 rebase conflict의 경우 current, incoming 두 가지 정보를 보여줍니다.
비슷하게 incoming을 최신 버전, current를 내 작업으로 처리해서 사용자에게 보여줍니다.
구분을  <<<<<와 ------으로 했으며 이 문구가 모두 지워지면 충돌 해결입니다.

### TuiEditor onChange 외부에서 넣어줄 수 있도록 개선

문서 충돌 해결 모달 내에서도 TuiEditor를 사용합니다.
이전에 TuiEditor를 수정하기, 작성하기 페이지에서만 사용했기 때문에 내부에서 zustand로 onChange를 받아와서 컴포넌트 내에서 수정해주었습니다. 그러나 이제 이 두 페이지 외 모달에서도 TuiEditor를 사용해야했기 때문에 onChange를 외부에서 받아와서 사용할 수 있도록 개선했습니다. (이 방향성이 맞긴하지)

### 시연 영상

### 1. 정상 수정# issue

- close #119 

## 구현 사항

문서 수정 시에 내가 수정하던 도중 다른 사람이 문서를 수정했을 때 덮어씌워지는 문제가 있었습니다.
이 문제를 개선하고자 문서 충돌 기능을 구현했습니다.

### 문서 충돌 판단 기준

문서 수정하기 페이지에 진입했을 때 서버에서 최신의 문서를 가져옵니다 (최신 버전을 기준으로 수정해야하므로)
이 때 현재 문서의 최신 버전 latestVersion을 가져오도록 기능이 추가되었습니다. 이를 사용해서 판단합니다.
사용자가 문서를 수정하고 버튼을 누를 때, 페이지 진입 시 가져왔던 버전과 버튼을 누를 시점의 버전이 다르다면 내가 수정하던 도중 다른 사람이 문서를 수정한 경우입니다.

이 때 충돌 모달을 띄워서 사용자에게 충돌을 직접 해결하도록 했습니다. 충돌 표시는 git과 유사하게 했습니다.
(크루위키를 사용하는 유저들은 모두 개발자임으로 git 충돌 해결하는 방법은 알겠죠?ㅋㅋㅋㅋㅋㅋ)

### 문서 충돌 해결방법
git merge나 rebase conflict의 경우 current, incoming 두 가지 정보를 보여줍니다.
비슷하게 incoming을 최신 버전, current를 내 작업으로 처리해서 사용자에게 보여줍니다.
구분을  <<<<<와 ------으로 했으며 이 문구가 모두 지워지면 충돌 해결입니다.

### TuiEditor onChange 외부에서 넣어줄 수 있도록 개선

문서 충돌 해결 모달 내에서도 TuiEditor를 사용합니다.
이전에 TuiEditor를 수정하기, 작성하기 페이지에서만 사용했기 때문에 내부에서 zustand로 onChange를 받아와서 컴포넌트 내에서 수정해주었습니다. 그러나 이제 이 두 페이지 외 모달에서도 TuiEditor를 사용해야했기 때문에 onChange를 외부에서 받아와서 사용할 수 있도록 개선했습니다. (이 방향성이 맞긴하지)

### 시연 영상

참고로 dev 환경 캐시 업데이트 문제로 수정 완료 시 바로 최신 데이터가 보이지 않아요.

### 1. 정상 수정

https://github.com/user-attachments/assets/9cdcdb1c-30e8-41d8-8270-ce26d6ba15d7

### 2. 문서 충돌 상황

https://github.com/user-attachments/assets/893f47e9-eb7b-4079-85a7-8919b740cfc5

### 3. 문서 재충돌 상황

https://github.com/user-attachments/assets/0d51ddbf-7bb2-4c83-8ff9-0f8a48308ccb


## 🫡 참고사항

아래는 제가 기능을 구현하면서 작성한 기능명세서입니다.
초안을 작성하고 AI에게 검토 및 보완을 부탁했는데 퀄리티가 꽤 좋은 것 같아서 공유합니다.
이 내용을 읽으면 더 이해가 잘 될거에요.

# 문서 충돌 해결 기능 명세서

## 1. 개요

사용자가 문서를 편집하고 저장할 때, 다른 사용자가 먼저 동일한 문서를 수정하여 발생할 수 있는 데이터 유실(덮어쓰기) 문제를 방지합니다. 충돌이 감지되면 사용자에게 두 버전의 차이점을 보여주는 UI를 제공하고, 사용자가 직접 내용을 병합하여 안전하게 저장할 수 있도록 돕는 기능을 구현합니다.

---

## 2. 사용자 시나리오

### 2.1. 충돌이 발생하는 경우

1.  **사용자 A**가 '문서 X' (버전 1)의 편집 페이지에 진입합니다.
2.  **사용자 B**가 동시에 '문서 X' (버전 1)의 편집 페이지에 진입합니다.
3.  **사용자 A**가 내용을 수정한 뒤 '작성완료' 버튼을 클릭하여 **버전 2**를 생성합니다.
4.  **사용자 B**가 내용을 수정한 뒤 '작성완료' 버튼을 클릭합니다.
5.  시스템은 사용자 B가 편집을 시작한 버전(1)과 현재 최신 버전(2)이 다름을 감지합니다.
6.  사용자 B에게 '문서 충돌 해결' 모달이 나타납니다.
7.  모달 내 편집기에는 **사용자 A가 수정한 내용(최신 버전)**과 **사용자 B가 수정한 내용(내 작업)**이 충돌 마커(e.g., `<<<<<`, `>>>>>`)와 함께 표시됩니다.
8.  사용자 B는 편집기 내에서 두 내용을 확인하고, 직접 텍스트를 수정하여 최종 버전을 만듭니다. (충돌 마커를 모두 제거합니다.)
9.  충돌 마커가 모두 제거되면 '충돌 해결 완료' 버튼이 활성화됩니다.
10. 사용자 B가 '충돌 해결 완료' 버튼을 클릭하면, 병합된 내용으로 문서가 최종 저장됩니다.

### 2.2. 충돌이 발생하지 않는 경우

1.  **사용자 A**가 '문서 X' (버전 1)의 편집 페이지에 진입합니다.
2.  **사용자 A**가 내용을 수정한 뒤 '작성완료' 버튼을 클릭합니다.
3.  시스템은 사용자가 편집을 시작한 버전(1)과 현재 최신 버전(1)이 동일함을 확인합니다.
4.  정상적으로 수정 내용이 저장되고 **버전 2**가 생성됩니다.

---

## 3. 기능 명세

### 3.1. 버전 충돌 감지

- **시점**: 문서 편집 페이지에서 '작성완료' 버튼 클릭 시.
- **전제 조건**:
  - 문서 편집 페이지 로드 시, 해당 문서의 내용과 **현재 버전(`originalVersion`)**을 클라이언트 상태로 저장하고 있어야 합니다.
- **프로세스**:
  1.  '작성완료' 버튼 클릭 이벤트를 가로챕니다.
  2.  `GET /document/{uuid}/log` API를 호출하여 문서의 최신 로그 정보를 가져옵니다.
  3.  API 응답에서 가장 최근 로그의 버전(`latestVersion`)을 확인합니다.
  4.  클라이언트에 저장된 `originalVersion`과 서버에서 받은 `latestVersion`을 비교합니다.
  5.  **`originalVersion !== latestVersion`** 이면 충돌로 간주하고, 3.2의 '충돌 해결 UI'를 실행합니다.
  6.  **`originalVersion === latestVersion`** 이면 정상 저장 로직을 수행합니다.

### 3.2. 충돌 해결 UI (모달)

- **구현 방식**: React Portal (`CreatePortal`)을 사용하여 `document.body`의 최상단에 렌더링합니다.
- **구성 요소**:
  1.  **모달 컨테이너**:
      - 모달 외부의 어두운 배경(Overlay)을 가집니다.
      - 배경 클릭 시 모달이 닫히고, 문서 저장 작업은 **취소**됩니다. 사용자에게 "저장되지 않은 변경사항이 있습니다. 정말 나가시겠습니까?"와 같은 확인(confirm) 메시지를 띄우는 것을 권장합니다.
  2.  **제목**: "문서 충돌 해결"
  3.  **설명**: "다른 사용자가 문서를 수정했습니다. 아래 내용을 병합하여 저장해주세요."
  4.  **편집기(Editor)**:
      - 3.3의 비교 알고리즘을 통해 생성된 병합용 텍스트를 표시합니다.
      - 최신 버전(Remote)과 내 작업(Local) 내용은 시각적으로 구분되어야 합니다.
        - `<<<<< 최신 버전` ~ `=====` 구간: 배경색 (e.g., `rgba(255, 0, 0, 0.1)`)
        - `=====` ~ `>>>>> 내 작업` 구간: 배경색 (e.g., `rgba(0, 0, 255, 0.1)`)
  5.  **'충돌 해결 완료' 버튼**:
      - **초기 상태**: 비활성화(`disabled`).
      - **활성화 조건**: 편집기 내의 텍스트에서 `<<<<<`, `=====`, `>>>>>` 패턴의 문자열이 모두 사라졌을 때 활성화됩니다. (실시간으로 편집기 내용을 파싱하여 상태를 업데이트해야 합니다.)
      - **클릭 이벤트**: 클릭 시, 3.4의 '충돌 해결 및 저장' 로직을 실행합니다.
  6.  **'취소' 버튼 또는 닫기(X) 아이콘**:
      - 클릭 시 모달이 닫히고, 문서 저장 작업은 **취소**됩니다. (외부 영역 클릭과 동일)

### 3.3. 충돌 내용 비교 알고리즘

- **목표**: 두 텍스트(서버의 최신 버전, 사용자의 현재 편집 내용)를 비교하여 Git과 유사한 충돌 형식의 문자열을 생성합니다.
- **알고리즘 제안**:
  - **Levenshtein 알고리즘**은 두 문자열 간의 유사도를 측정하는 데는 유용하지만, 어떤 내용이 추가/삭제/변경되었는지 시각적으로 보여주는 'diff' 결과물을 만드는 데는 적합하지 않습니다.
  - **Line-by-line Diff 알고리즘** (예: Myers Diff Algorithm)을 사용하는 것을 권장합니다. 이 방식은 줄 단위로 변경 사항을 추적하여 Git이 보여주는 것과 유사한 결과를 생성할 수 있습니다.
  - **추천 라이브러리**: `diff-match-patch` 또는 `jsdiff` 와 같은 검증된 라이브러리 사용을 권장합니다. 이 라이브러리들은 두 텍스트를 비교하여 변경된 부분을 상세히 알려주므로, 이를 가공하여 `<<<<<` 형식의 결과물을 쉽게 만들 수 있습니다.
- **프로세스**:
  1.  충돌이 감지되면, 서버로부터 최신 버전의 문서 내용(`remoteContent`)을 추가로 가져옵니다. (`GET /document/{uuid}`)
  2.  사용자가 편집 중인 내용(`localContent`)과 `remoteContent`를 Diff 라이브러리에 전달합니다.
  3.  라이브러리가 반환한 diff 결과를 파싱하여 아래 형식의 문자열로 재조합합니다.
      ```diff
      공통 내용...
      <<<<< 최신 버전
      서버의 최신 내용 중 다른 부분
      =====
      내가 수정한 내용 중 다른 부분
      >>>>> 내 작업
      공통 내용...
      ```

### 3.4. 충돌 해결 및 저장

- **시점**: '충돌 해결 완료' 버튼 클릭 시.
- **프로세스**:
  1.  충돌 해결 편집기 내부의 최종 텍스트 전체를 가져옵니다.
  2.  기존의 문서 수정 API (`POST /document/{uuid}`)를 호출합니다.
  3.  API 요청 본문(body)에 최종 텍스트를 담아 전송합니다.
  4.  API 호출이 성공하면, 사용자에게 "성공적으로 저장되었습니다"와 같은 피드백을 주고 편집 페이지를 벗어나거나 뷰 페이지로 이동시킵니다.
  5.  **[중요] 재충돌 방지**: '충돌 해결 완료' 버튼을 눌러 저장하는 시점에도 그 사이에 또 다른 버전이 생겼을 수 있습니다. 따라서 저장 직전에 `GET /document/{uuid}/log`를 다시 호출하여 `latestVersion`이 이전 단계(3.1)에서 확인한 `latestVersion`과 동일한지 **한 번 더 확인**하는 로직을 추가하는 것을 강력히 권장합니다. 만약 또 충돌했다면, 사용자에게 "병합하는 동안 새로운 변경사항이 생겼습니다. 페이지를 새로고침하여 다시 시도해주세요." 와 같은 메시지를 보여주고 프로세스를 처음부터 다시 시작하도록 유도합니다.

---

## 4. 테스트 케이스

### 4.1. 정상 케이스

- **TC-N-01**: 충돌 없이 문서가 정상적으로 저장된다.
- **TC-N-02**: 충돌 발생 후, 사용자가 내용을 성공적으로 병합하고 '충돌 해결 완료' 버튼을 눌러 저장에 성공한다.
- **TC-N-03**: 충돌 해결 UI에서 충돌 마커(`<<<<<` 등)가 하나라도 남아있으면 '충돌 해결 완료' 버튼이 비활성화 상태를 유지한다.
- **TC-N-04**: 충돌 마커를 모두 제거하면 '충돌 해결 완료' 버튼이 즉시 활성화된다.

### 4.2. 예외 케이스

- **TC-E-01**: '작성완료' 클릭 시 `/document/{uuid}/log` API 호출에 실패하면, 사용자에게 "최신 버전을 확인하는데 실패했습니다. 잠시 후 다시 시도해주세요." 와 같은 에러 메시지를 표시한다.
- **TC-E-02**: 충돌 해결 UI를 띄우기 위해 최신 문서 내용을 가져오는 API (`GET /document/{uuid}`) 호출에 실패하면, "최신 내용을 가져오는데 실패했습니다." 에러 메시지를 표시한다.
- **TC-E-03**: 충돌 해결 모달의 외부 영역이나 '취소' 버튼을 클릭하면, 저장 프로세스가 중단되고 모달이 닫힌다.
- **TC-E-04**: '충돌 해결 완료' 버튼을 눌러 최종 저장을 시도했으나 API 호출에 실패하면, "저장에 실패했습니다." 에러 메시지를 표시하고 편집기 내용은 그대로 유지한다.
- **TC-E-05 (재충돌)**: 충돌을 해결하고 저장하는 사이 다른 사용자가 또 문서를 수정했을 경우(3.4의 재충돌 방지 로직), "병합하는 동안 새로운 변경사항이 생겼습니다..." 메시지를 표시하고 저장을 막는다.

### 4.3. 경계 케이스

- **TC-B-01**: 완전히 비어있는 문서에서 두 사용자가 각각 내용을 추가하고 저장하여 충돌이 발생했을 때, diff가 정상적으로 표시되는지 확인한다.
- **TC-B-02**: 문서 전체 내용이 완전히 다르게 수정되었을 때, 문서 전체가 충돌 블록으로 감싸져 표시되는지 확인한다.
- **TC-B-03**: 문서의 맨 첫 줄과 맨 마지막 줄에서 동시에 수정이 일어나 충돌했을 때, diff가 정상적으로 표시되는지 확인한다.
- **TC-B-04**: 한 사용자는 내용을 추가하고 다른 사용자는 내용을 삭제하여 충돌이 발생했을 때, diff가 정상적으로 표시되는지 확인한다.



