### PR TITLE
문서 수정하기 페이지 진입 시 [Object, Object] 편집하기 해결

### DIFF
--- a/client/src/app/wiki/[uuid]/edit/layout.tsx
+++ b/client/src/app/wiki/[uuid]/edit/layout.tsx
@@ -7,8 +7,10 @@ export async function generateMetadata({params}: UUIDParams): Promise<Metadata> 
   const document = await getDocumentByUUIDServer(uuid);
 
   return {
-    title: `${document?.title} 편집하기`,
-    description: `${document?.title}의 새로운 정보(논란)를 공유해주세요!`,
+    title: document ? `${document.title} 편집하기` : '편집하기',
+    description: document
+      ? `${document?.title}의 새로운 정보(논란)를 공유해주세요!`
+      : '새로운 정보(논란)를 공유해주세요!',
   };
 }
 


### PR DESCRIPTION
## issue

- close #141 

## 구현 사항

### Object Object 해결

generateMetadata에서 document 전체를 title에 넣어주고 있었습니다.
그래서 여기서 title만 메타데이터에 넣어주도록 수정했습니다.

<img width="590" height="78" alt="image" src="https://github.com/user-attachments/assets/331e6ade-fa09-4be6-85ee-9bb2e3bc2247" />


## 🫡 참고사항
