### PR TITLE
조직 문서 조회 시 연결된 크루 문서 목록 제공

### DIFF
--- a/.github/workflows/close-issue-on-pr-merge.yml
+++ b/.github/workflows/close-issue-on-pr-merge.yml
@@ -3,6 +3,7 @@ name: Close Issue on PR Merge
 on:
   pull_request:
     types: [closed]
+    branches: ['develop/**']
 
 jobs:
   close-issue:

--- a/.github/workflows/frontend-dev-deploy.yml
+++ b/.github/workflows/frontend-dev-deploy.yml
@@ -3,7 +3,7 @@ name: frontend-dev-deploy
 on:
   push:
     branches:
-      - develop
+      - 'develop/**'
 
 jobs:
   deploy:
@@ -82,8 +82,9 @@ jobs:
 
             echo "🔄 Pulling latest code from Git..."
             # git 충돌 방지를 위한 강제 덮어쓰기
-            git fetch origin develop
-            git reset --hard origin/develop
+            BRANCH_NAME="${GITHUB_REF#refs/heads/}"
+            git fetch origin "$BRANCH_NAME"
+            git reset --hard "origin/$BRANCH_NAME"
 
             echo "📂 Checking build file..."
             if [ ! -f next-build.tar.gz ]; then

--- a/.github/workflows/sync-issue-to-pr.yml
+++ b/.github/workflows/sync-issue-to-pr.yml
@@ -3,7 +3,7 @@ name: Sync Issue Info to PR
 on:
   pull_request:
     types: [opened]
-    branches: [develop]
+    branches: ['develop/**']
 
 jobs:
   sync-issue-meta:

--- a/client/scripts/prepare-release.mjs
+++ b/client/scripts/prepare-release.mjs
@@ -39,6 +39,10 @@ function isValidVersion(version) {
 /* ------------------ branch ------------------ */
 const BRANCH = execSync('git branch --show-current').toString().trim();
 
+if (!/^[a-zA-Z0-9._\-/]+$/.test(BRANCH)) {
+  fail(`브랜치 이름에 허용되지 않는 문자가 포함되어 있습니다. (현재: ${BRANCH})`);
+}
+
 /* ------------------ pre checks ------------------ */
 function ensureGhInstalled() {
   try {

--- a/client/scripts/prepare-release.mjs
+++ b/client/scripts/prepare-release.mjs
@@ -36,6 +36,9 @@ function isValidVersion(version) {
   return /^\d+\.\d+\.\d+$/.test(version);
 }
 
+/* ------------------ branch ------------------ */
+const BRANCH = execSync('git branch --show-current').toString().trim();
+
 /* ------------------ pre checks ------------------ */
 function ensureGhInstalled() {
   try {
@@ -54,9 +57,8 @@ function ensureGhAuthenticated() {
 }
 
 function ensureDevelopBranch() {
-  const branch = run('git branch --show-current', true);
-  if (branch !== 'develop') {
-    fail(`현재 브랜치가 develop이 아닙니다. (현재: ${branch})`);
+  if (!BRANCH.startsWith('develop')) {
+    fail(`현재 브랜치가 develop으로 시작하지 않습니다. (현재: ${BRANCH})`);
   }
 }
 
@@ -65,7 +67,7 @@ function ensureNoOpenReleasePr() {
     `gh pr list \
       --repo ${FULL_REPO} \
       --base main \
-      --head develop \
+      --head ${BRANCH} \
       --state open \
       --json number \
       --jq "length"`,
@@ -136,7 +138,7 @@ rl.question('다음 배포 버전을 입력해주세요 ex) X.Y.Z : ', version =
     run(`git commit -m "chore: release v${version}"`);
 
     /* 4. push */
-    run('git push origin develop');
+    run(`git push origin ${BRANCH}`);
 
     /* 5. 릴리즈 노트 */
     const notes = generateReleaseNotes(version);
@@ -147,7 +149,7 @@ rl.question('다음 배포 버전을 입력해주세요 ex) X.Y.Z : ', version =
       `gh pr create \
         --repo ${FULL_REPO} \
         --base main \
-        --head develop \
+        --head ${BRANCH} \
         --title "v${version} 배포" \
         --body-file "${RELEASE_NOTES_TMP}"`,
     );

--- a/client/src/apis/client/organization.ts
+++ b/client/src/apis/client/organization.ts
@@ -1,7 +1,13 @@
 'use client';
 
 import {CLIENT_ENDPOINT, ENDPOINT} from '@constants/endpoint';
-import {requestDeleteClient, requestGetClient, requestPostClient, requestPutClient} from '@http/client';
+import {
+  requestDeleteClient,
+  requestGetClient,
+  requestPostClient,
+  requestPostClientWithoutResponse,
+  requestPutClient,
+} from '@http/client';
 import {
   GroupDocumentResponse,
   OrganizationDocumentCreateRequest,
@@ -57,7 +63,7 @@ export const deleteOrganizationFromDocumentClient = async (documentUuid: string,
 };
 
 export const revalidateOrganizationDocumentClient = async (organizationDocumentUuids: string[]) => {
-  await requestPostClient({
+  await requestPostClientWithoutResponse({
     baseUrl: process.env.NEXT_PUBLIC_FRONTEND_SERVER_BASE_URL,
     endpoint: CLIENT_ENDPOINT.revalidateOrganizationDocument,
     body: {organizationDocumentUuids},

--- a/client/src/apis/client/organization.ts
+++ b/client/src/apis/client/organization.ts
@@ -55,3 +55,11 @@ export const deleteOrganizationFromDocumentClient = async (documentUuid: string,
     endpoint: ENDPOINT.deleteOrganizationFromDocument(documentUuid, organizationDocumentUuid),
   });
 };
+
+export const revalidateOrganizationDocumentClient = async (organizationDocumentUuids: string[]) => {
+  await requestPostClient({
+    baseUrl: process.env.NEXT_PUBLIC_FRONTEND_SERVER_BASE_URL,
+    endpoint: CLIENT_ENDPOINT.revalidateOrganizationDocument,
+    body: {organizationDocumentUuids},
+  });
+};

--- a/client/src/app/api/revalidate-organization-document/route.ts
+++ b/client/src/app/api/revalidate-organization-document/route.ts
@@ -1,0 +1,25 @@
+'use server';
+
+import {CACHE} from '@constants/cache';
+import {ApiResponseType} from '@type/http.type';
+import {revalidateTag} from 'next/cache';
+import {NextRequest, NextResponse} from 'next/server';
+
+export const POST = async (request: NextRequest) => {
+  try {
+    const {organizationDocumentUuids}: {organizationDocumentUuids: string[]} = await request.json();
+
+    organizationDocumentUuids.forEach(uuid => {
+      revalidateTag(CACHE.tag.getOrganizationDocumentByUUID(uuid));
+    });
+
+    return new Response(null, {status: 204});
+  } catch (error) {
+    const response: ApiResponseType<null> = {
+      data: null,
+      code: 'ERROR',
+      message: error instanceof Error ? error.message : '알 수 없는 오류가 발생했습니다.',
+    };
+    return NextResponse.json(response, {status: 500});
+  }
+};

--- a/client/src/app/wiki/groups/[uuid]/page.tsx
+++ b/client/src/app/wiki/groups/[uuid]/page.tsx
@@ -36,7 +36,7 @@ const GroupPage = async ({params}: {params: Promise<{uuid: string}>}) => {
         <TOC headTags={extractHeadings(htmlContents)} />
         <div className="toastui-editor-contents" dangerouslySetInnerHTML={{__html: htmlContents}} />
 
-        <CrewMemberSection crewDocuments={groupDocument.linkedCrewDocuments} />
+        <CrewMemberSection crewDocuments={groupDocument.linkedCrewDocuments ?? []} />
         <TimelineSection events={groupDocument.organizationEventResponses} organizationDocumentUuid={uuid} />
       </section>
       <DocumentFooter generateTime={groupDocument.generateTime} />

--- a/client/src/app/wiki/groups/[uuid]/page.tsx
+++ b/client/src/app/wiki/groups/[uuid]/page.tsx
@@ -8,6 +8,7 @@ import {processHtmlContent} from '@utils/processHtmlContent';
 import TOC from '@components/document/TOC/TOC';
 import '@components/document/layout/toastui-editor-viewer.css';
 import {getOrganizationDocumentByUUIDServer} from '@apis/server/organizationDocument';
+import CrewMemberSection from '@components/document/layout/CrewMemberSection';
 
 const GroupPage = async ({params}: {params: Promise<{uuid: string}>}) => {
   const {uuid} = await params;
@@ -35,6 +36,7 @@ const GroupPage = async ({params}: {params: Promise<{uuid: string}>}) => {
         <TOC headTags={extractHeadings(htmlContents)} />
         <div className="toastui-editor-contents" dangerouslySetInnerHTML={{__html: htmlContents}} />
 
+        <CrewMemberSection crewDocuments={groupDocument.linkedCrewDocuments} />
         <TimelineSection events={groupDocument.organizationEventResponses} organizationDocumentUuid={uuid} />
       </section>
       <DocumentFooter generateTime={groupDocument.generateTime} />

--- a/client/src/components/document/layout/CrewMemberSection.tsx
+++ b/client/src/components/document/layout/CrewMemberSection.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import {useRouter} from 'next/navigation';
+import {LinkedCrewDocumentResponse} from '@type/Group.type';
+import {Chip} from '@components/common/Chip';
+import {route} from '@constants/route';
+
+interface CrewMemberSectionProps {
+  crewDocuments: LinkedCrewDocumentResponse[];
+}
+
+const CrewMemberSection = ({crewDocuments}: CrewMemberSectionProps) => {
+  const router = useRouter();
+
+  if (crewDocuments.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="-mt-4">
+      <div className="flex flex-wrap gap-2">
+        {crewDocuments.map(crew => (
+          <Chip
+            key={crew.documentUuid}
+            text={crew.title}
+            variant="link"
+            onClick={() => router.push(route.goWiki(crew.documentUuid))}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default CrewMemberSection;

--- a/client/src/constants/endpoint.ts
+++ b/client/src/constants/endpoint.ts
@@ -44,6 +44,7 @@ export const CLIENT_ENDPOINT = {
   // Organization
   putOrganizationDocument: '/api/put-organization-document',
   postOrganizationEvent: '/api/post-organization-event',
+  revalidateOrganizationDocument: '/api/revalidate-organization-document',
 
   // View Count
   postViewCount: '/api/post-view-count',

--- a/client/src/hooks/mutation/usePostDocument.ts
+++ b/client/src/hooks/mutation/usePostDocument.ts
@@ -4,7 +4,11 @@ import useMutation from '@hooks/useMutation';
 import {DOCUMENT_TYPE, PostDocumentContent, WikiDocument} from '@type/Document.type';
 import useAmplitude from '@hooks/useAmplitude';
 import {postDocumentClient} from '@apis/client/document';
-import {postOrganizationDocumentClient, linkOrganizationDocumentClient} from '@apis/client/organization';
+import {
+  postOrganizationDocumentClient,
+  linkOrganizationDocumentClient,
+  revalidateOrganizationDocumentClient,
+} from '@apis/client/organization';
 import {useTrie} from '@store/trie';
 import {route} from '@constants/route';
 import {GroupDocumentResponse} from '@type/Group.type';
@@ -35,6 +39,13 @@ const postDocumentWithOrganizations = async (document: PostDocumentContent) => {
       }),
     ),
   );
+
+  const organizationUuidsToRevalidate = [...createdOrganizations, ...linkedOrganizations].map(
+    org => org.organizationDocumentUuid,
+  );
+  if (organizationUuidsToRevalidate.length > 0) {
+    await revalidateOrganizationDocumentClient(organizationUuidsToRevalidate);
+  }
 
   return {savedDocument, createdOrganizations: [...createdOrganizations, ...linkedOrganizations]};
 };

--- a/client/src/hooks/mutation/usePostDocument.ts
+++ b/client/src/hooks/mutation/usePostDocument.ts
@@ -46,8 +46,8 @@ const postDocumentWithOrganizations = async (document: PostDocumentContent) => {
   if (organizationUuidsToRevalidate.length > 0) {
     try {
       await revalidateOrganizationDocumentClient(organizationUuidsToRevalidate);
-    } catch {
-      // 캐시 무효화 실패해도 사용자 플로우를 차단하지 않음
+    } catch (error) {
+      console.error('Failed to revalidate organization document cache on post:', error);
     }
   }
 

--- a/client/src/hooks/mutation/usePostDocument.ts
+++ b/client/src/hooks/mutation/usePostDocument.ts
@@ -1,5 +1,6 @@
 'use client';
 
+import * as Sentry from '@sentry/nextjs';
 import useMutation from '@hooks/useMutation';
 import {DOCUMENT_TYPE, PostDocumentContent, WikiDocument} from '@type/Document.type';
 import useAmplitude from '@hooks/useAmplitude';
@@ -47,7 +48,10 @@ const postDocumentWithOrganizations = async (document: PostDocumentContent) => {
     try {
       await revalidateOrganizationDocumentClient(organizationUuidsToRevalidate);
     } catch (error) {
-      console.error('Failed to revalidate organization document cache on post:', error);
+      Sentry.captureException(error, {
+        tags: {action: 'revalidate-organization-cache'},
+        extra: {organizationUuidsToRevalidate},
+      });
     }
   }
 

--- a/client/src/hooks/mutation/usePostDocument.ts
+++ b/client/src/hooks/mutation/usePostDocument.ts
@@ -44,7 +44,11 @@ const postDocumentWithOrganizations = async (document: PostDocumentContent) => {
     org => org.organizationDocumentUuid,
   );
   if (organizationUuidsToRevalidate.length > 0) {
-    await revalidateOrganizationDocumentClient(organizationUuidsToRevalidate);
+    try {
+      await revalidateOrganizationDocumentClient(organizationUuidsToRevalidate);
+    } catch {
+      // 캐시 무효화 실패해도 사용자 플로우를 차단하지 않음
+    }
   }
 
   return {savedDocument, createdOrganizations: [...createdOrganizations, ...linkedOrganizations]};

--- a/client/src/hooks/mutation/usePutDocument.ts
+++ b/client/src/hooks/mutation/usePutDocument.ts
@@ -1,5 +1,6 @@
 'use client';
 
+import * as Sentry from '@sentry/nextjs';
 import useMutation from '@hooks/useMutation';
 import {DOCUMENT_TYPE, PostDocumentContent, WikiDocument} from '@type/Document.type';
 import useAmplitude from '@hooks/useAmplitude';
@@ -69,7 +70,10 @@ export const usePutDocument = () => {
       try {
         await revalidateOrganizationDocumentClient(organizationUuidsToRevalidate);
       } catch (error) {
-        console.error('Failed to revalidate organization document cache on put:', error);
+        Sentry.captureException(error, {
+          tags: {action: 'revalidate-organization-cache'},
+          extra: {organizationUuidsToRevalidate},
+        });
       }
     }
 

--- a/client/src/hooks/mutation/usePutDocument.ts
+++ b/client/src/hooks/mutation/usePutDocument.ts
@@ -68,8 +68,8 @@ export const usePutDocument = () => {
     if (organizationUuidsToRevalidate.length > 0) {
       try {
         await revalidateOrganizationDocumentClient(organizationUuidsToRevalidate);
-      } catch {
-        // 캐시 무효화 실패해도 사용자 플로우를 차단하지 않음
+      } catch (error) {
+        console.error('Failed to revalidate organization document cache on put:', error);
       }
     }
 

--- a/client/src/hooks/mutation/usePutDocument.ts
+++ b/client/src/hooks/mutation/usePutDocument.ts
@@ -8,6 +8,7 @@ import {
   deleteOrganizationFromDocumentClient,
   linkOrganizationDocumentClient,
   postOrganizationDocumentClient,
+  revalidateOrganizationDocumentClient,
 } from '@apis/client/organization';
 import {useTrie} from '@store/trie';
 import {useDocument} from '@store/document';
@@ -58,6 +59,15 @@ export const usePutDocument = () => {
     await Promise.all(
       deletedOrganizations.map(org => deleteOrganizationFromDocumentClient(savedDocument.documentUUID, org.uuid)),
     );
+
+    const organizationUuidsToRevalidate = [
+      ...createdOrganizations.map(org => org.organizationDocumentUuid),
+      ...linkedOrganizations.map(org => org.organizationDocumentUuid),
+      ...deletedOrganizations.map(org => org.uuid),
+    ];
+    if (organizationUuidsToRevalidate.length > 0) {
+      await revalidateOrganizationDocumentClient(organizationUuidsToRevalidate);
+    }
 
     return {savedDocument, createdOrganizations: [...createdOrganizations, ...linkedOrganizations]};
   };

--- a/client/src/hooks/mutation/usePutDocument.ts
+++ b/client/src/hooks/mutation/usePutDocument.ts
@@ -66,7 +66,11 @@ export const usePutDocument = () => {
       ...deletedOrganizations.map(org => org.uuid),
     ];
     if (organizationUuidsToRevalidate.length > 0) {
-      await revalidateOrganizationDocumentClient(organizationUuidsToRevalidate);
+      try {
+        await revalidateOrganizationDocumentClient(organizationUuidsToRevalidate);
+      } catch {
+        // 캐시 무효화 실패해도 사용자 플로우를 차단하지 않음
+      }
     }
 
     return {savedDocument, createdOrganizations: [...createdOrganizations, ...linkedOrganizations]};

--- a/client/src/type/Group.type.ts
+++ b/client/src/type/Group.type.ts
@@ -31,6 +31,11 @@ export interface OrganizationEventResponse {
   occurredAt: string;
 }
 
+export interface LinkedCrewDocumentResponse {
+  documentUuid: string;
+  title: string;
+}
+
 // 조직 문서 및 이벤트 조회 응답 타입
 export interface OrganizationDocumentWithEventsResponse {
   organizationDocumentId: number;
@@ -40,6 +45,7 @@ export interface OrganizationDocumentWithEventsResponse {
   writer: string;
   generateTime: string;
   organizationEventResponses: OrganizationEventResponse[];
+  linkedCrewDocuments: LinkedCrewDocumentResponse[];
 }
 
 // 기존 조직 문서 연결 요청 타입


### PR DESCRIPTION
## issue

- close #212 

## 구현 사항

 ### 1. 조직 문서에서 연결된 크루 구성원 목록 표시                                                                 
  - 조직 문서에 해당 조직에 소속된 크루 목록을 Chip으로 표시
  - 조직 문서에서 조직원 Chip 클릭 시 해당 크루 문서 페이지로 이동(크루 -> 조직으로 이동되는 것과 같음)
  - `GET /organization/uuid/{uuidText}` API 응답에 추가된 `linkedCrewDocuments` 필드 활용
                                           
<img width="318" height="1198" alt="CleanShot 2026-03-12 at 00 58 39@2x" src="https://github.com/user-attachments/assets/c7571949-7050-4ea5-821a-aa3506fc77ad" />
    
  ### 2. 크루 문서 생성/수정 시 조직 문서 캐시 무효화
지난번 '문서의 소속 정보가 즉시 반영되지 않는 캐시 문제'가 있어서 핫픽스를 했는데, 이번 기능을 구현하면서 캐시에 신경을 썼어요.

  - 크루 문서에서 조직을 연결하거나 해제하면, 해당 조직 문서의 서버 캐시를 즉시 무효화
  - 프로덕션 환경에서 조직 문서 페이지의 구성원 목록이 최신 상태로 반영
  - 캐시 무효화 실패 시에도 사용자의 문서 저장 플로우는 정상 동작 (best-effort)

  ### 3. develop 브랜치 전략 변경

디스코드 프론트 회의에서 논의된 것과 같이 브랜치 전략을 변경했어요. 

  - 기존 develop 브랜치 -> 삭제하지 않고 temp/develop-backup 로 이름 변경
  - `develop` → `develop/vX.Y.Z` 브랜치 네이밍 전략 변경
  - 배포 스크립트(`prepare-release.mjs`)와 GitHub 워크플로우를 새 전략에 맞게 수정
  - GitHub 레포 Settings에서 Branch protection rules에 develop 관련 규칙을 `develop/*`로 변경

## 중점적으로 리뷰받고 싶은 부분(선택)

### 캐시 무효화 방식                                                                                                       
크루 문서 저장 후, 클라이언트에서 조직 문서 캐시를 무효화하는 API(`/api/revalidate-organization-document`)를 별도로 호출하는 구조입니다.
문서 저장과 조직 연결이 별도 API로 분리되어 있어서, **조직 연결이 완료된 시점**에 캐시를 무효화해야 하기 때문에 이 방식을 선택했어요.
캐시 무효화에 실패하더라도 사용자 플로우를 차단하지 않도록 try-catch로 감쌌는데, 이 판단이 적절할지 의견 부탁드립니다!

## 🫡 참고사항

백엔드 코드가 먼저 dev -> main으로 머지된 후 이 기능을 배포합니다.