### PR TITLE
v3.4.0 배포

### DIFF
--- a/.github/workflows/close-issue-on-pr-merge.yml
+++ b/.github/workflows/close-issue-on-pr-merge.yml
@@ -3,6 +3,7 @@ name: Close Issue on PR Merge
 on:
   pull_request:
     types: [closed]
+    branches: ['develop/**']
 
 jobs:
   close-issue:

--- a/.github/workflows/frontend-dev-deploy.yml
+++ b/.github/workflows/frontend-dev-deploy.yml
@@ -3,7 +3,7 @@ name: frontend-dev-deploy
 on:
   push:
     branches:
-      - develop
+      - 'develop/**'
 
 jobs:
   deploy:
@@ -82,8 +82,9 @@ jobs:
 
             echo "🔄 Pulling latest code from Git..."
             # git 충돌 방지를 위한 강제 덮어쓰기
-            git fetch origin develop
-            git reset --hard origin/develop
+            BRANCH_NAME="${GITHUB_REF#refs/heads/}"
+            git fetch origin "$BRANCH_NAME"
+            git reset --hard "origin/$BRANCH_NAME"
 
             echo "📂 Checking build file..."
             if [ ! -f next-build.tar.gz ]; then

--- a/.github/workflows/sync-issue-to-pr.yml
+++ b/.github/workflows/sync-issue-to-pr.yml
@@ -3,7 +3,7 @@ name: Sync Issue Info to PR
 on:
   pull_request:
     types: [opened]
-    branches: [develop]
+    branches: ['develop/**']
 
 jobs:
   sync-issue-meta:

--- a/client/scripts/prepare-release.mjs
+++ b/client/scripts/prepare-release.mjs
@@ -36,6 +36,13 @@ function isValidVersion(version) {
   return /^\d+\.\d+\.\d+$/.test(version);
 }
 
+/* ------------------ branch ------------------ */
+const BRANCH = execSync('git branch --show-current').toString().trim();
+
+if (!/^[a-zA-Z0-9._\-/]+$/.test(BRANCH)) {
+  fail(`브랜치 이름에 허용되지 않는 문자가 포함되어 있습니다. (현재: ${BRANCH})`);
+}
+
 /* ------------------ pre checks ------------------ */
 function ensureGhInstalled() {
   try {
@@ -54,9 +61,8 @@ function ensureGhAuthenticated() {
 }
 
 function ensureDevelopBranch() {
-  const branch = run('git branch --show-current', true);
-  if (branch !== 'develop') {
-    fail(`현재 브랜치가 develop이 아닙니다. (현재: ${branch})`);
+  if (!BRANCH.startsWith('develop')) {
+    fail(`현재 브랜치가 develop으로 시작하지 않습니다. (현재: ${BRANCH})`);
   }
 }
 
@@ -65,7 +71,7 @@ function ensureNoOpenReleasePr() {
     `gh pr list \
       --repo ${FULL_REPO} \
       --base main \
-      --head develop \
+      --head ${BRANCH} \
       --state open \
       --json number \
       --jq "length"`,
@@ -136,7 +142,7 @@ rl.question('다음 배포 버전을 입력해주세요 ex) X.Y.Z : ', version =
     run(`git commit -m "chore: release v${version}"`);
 
     /* 4. push */
-    run('git push origin develop');
+    run(`git push origin ${BRANCH}`);
 
     /* 5. 릴리즈 노트 */
     const notes = generateReleaseNotes(version);
@@ -147,7 +153,7 @@ rl.question('다음 배포 버전을 입력해주세요 ex) X.Y.Z : ', version =
       `gh pr create \
         --repo ${FULL_REPO} \
         --base main \
-        --head develop \
+        --head ${BRANCH} \
         --title "v${version} 배포" \
         --body-file "${RELEASE_NOTES_TMP}"`,
     );

--- a/client/src/apis/client/organization.ts
+++ b/client/src/apis/client/organization.ts
@@ -1,7 +1,13 @@
 'use client';
 
 import {CLIENT_ENDPOINT, ENDPOINT} from '@constants/endpoint';
-import {requestDeleteClient, requestGetClient, requestPostClient, requestPutClient} from '@http/client';
+import {
+  requestDeleteClient,
+  requestGetClient,
+  requestPostClient,
+  requestPostClientWithoutResponse,
+  requestPutClient,
+} from '@http/client';
 import {
   GroupDocumentResponse,
   OrganizationDocumentCreateRequest,
@@ -53,5 +59,13 @@ export const deleteOrganizationFromDocumentClient = async (documentUuid: string,
   await requestDeleteClient({
     baseUrl: process.env.NEXT_PUBLIC_BACKEND_SERVER_BASE_URL,
     endpoint: ENDPOINT.deleteOrganizationFromDocument(documentUuid, organizationDocumentUuid),
+  });
+};
+
+export const revalidateOrganizationDocumentClient = async (organizationDocumentUuids: string[]) => {
+  await requestPostClientWithoutResponse({
+    baseUrl: process.env.NEXT_PUBLIC_FRONTEND_SERVER_BASE_URL,
+    endpoint: CLIENT_ENDPOINT.revalidateOrganizationDocument,
+    body: {organizationDocumentUuids},
   });
 };

--- a/client/src/app/api/revalidate-organization-document/route.ts
+++ b/client/src/app/api/revalidate-organization-document/route.ts
@@ -1,0 +1,25 @@
+'use server';
+
+import {CACHE} from '@constants/cache';
+import {ApiResponseType} from '@type/http.type';
+import {revalidateTag} from 'next/cache';
+import {NextRequest, NextResponse} from 'next/server';
+
+export const POST = async (request: NextRequest) => {
+  try {
+    const {organizationDocumentUuids}: {organizationDocumentUuids: string[]} = await request.json();
+
+    organizationDocumentUuids.forEach(uuid => {
+      revalidateTag(CACHE.tag.getOrganizationDocumentByUUID(uuid));
+    });
+
+    return new Response(null, {status: 204});
+  } catch (error) {
+    const response: ApiResponseType<null> = {
+      data: null,
+      code: 'ERROR',
+      message: error instanceof Error ? error.message : '알 수 없는 오류가 발생했습니다.',
+    };
+    return NextResponse.json(response, {status: 500});
+  }
+};

--- a/client/src/app/wiki/groups/[uuid]/page.tsx
+++ b/client/src/app/wiki/groups/[uuid]/page.tsx
@@ -8,6 +8,7 @@ import {processHtmlContent} from '@utils/processHtmlContent';
 import TOC from '@components/document/TOC/TOC';
 import '@components/document/layout/toastui-editor-viewer.css';
 import {getOrganizationDocumentByUUIDServer} from '@apis/server/organizationDocument';
+import CrewMemberSection from '@components/document/layout/CrewMemberSection';
 
 const GroupPage = async ({params}: {params: Promise<{uuid: string}>}) => {
   const {uuid} = await params;
@@ -35,6 +36,7 @@ const GroupPage = async ({params}: {params: Promise<{uuid: string}>}) => {
         <TOC headTags={extractHeadings(htmlContents)} />
         <div className="toastui-editor-contents" dangerouslySetInnerHTML={{__html: htmlContents}} />
 
+        <CrewMemberSection crewDocuments={groupDocument.linkedCrewDocuments ?? []} />
         <TimelineSection events={groupDocument.organizationEventResponses} organizationDocumentUuid={uuid} />
       </section>
       <DocumentFooter generateTime={groupDocument.generateTime} />

--- a/client/src/components/document/layout/CrewMemberSection.tsx
+++ b/client/src/components/document/layout/CrewMemberSection.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import {useRouter} from 'next/navigation';
+import {LinkedCrewDocumentResponse} from '@type/Group.type';
+import {Chip} from '@components/common/Chip';
+import {route} from '@constants/route';
+
+interface CrewMemberSectionProps {
+  crewDocuments: LinkedCrewDocumentResponse[];
+}
+
+const CrewMemberSection = ({crewDocuments}: CrewMemberSectionProps) => {
+  const router = useRouter();
+
+  if (crewDocuments.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="-mt-4">
+      <div className="flex flex-wrap gap-2">
+        {crewDocuments.map(crew => (
+          <Chip
+            key={crew.documentUuid}
+            text={crew.title}
+            variant="link"
+            onClick={() => router.push(route.goWiki(crew.documentUuid))}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default CrewMemberSection;

--- a/client/src/constants/endpoint.ts
+++ b/client/src/constants/endpoint.ts
@@ -44,6 +44,7 @@ export const CLIENT_ENDPOINT = {
   // Organization
   putOrganizationDocument: '/api/put-organization-document',
   postOrganizationEvent: '/api/post-organization-event',
+  revalidateOrganizationDocument: '/api/revalidate-organization-document',
 
   // View Count
   postViewCount: '/api/post-view-count',

--- a/client/src/hooks/mutation/usePostDocument.ts
+++ b/client/src/hooks/mutation/usePostDocument.ts
@@ -1,10 +1,15 @@
 'use client';
 
+import * as Sentry from '@sentry/nextjs';
 import useMutation from '@hooks/useMutation';
 import {DOCUMENT_TYPE, PostDocumentContent, WikiDocument} from '@type/Document.type';
 import useAmplitude from '@hooks/useAmplitude';
 import {postDocumentClient} from '@apis/client/document';
-import {postOrganizationDocumentClient, linkOrganizationDocumentClient} from '@apis/client/organization';
+import {
+  postOrganizationDocumentClient,
+  linkOrganizationDocumentClient,
+  revalidateOrganizationDocumentClient,
+} from '@apis/client/organization';
 import {useTrie} from '@store/trie';
 import {route} from '@constants/route';
 import {GroupDocumentResponse} from '@type/Group.type';
@@ -35,6 +40,20 @@ const postDocumentWithOrganizations = async (document: PostDocumentContent) => {
       }),
     ),
   );
+
+  const organizationUuidsToRevalidate = [...createdOrganizations, ...linkedOrganizations].map(
+    org => org.organizationDocumentUuid,
+  );
+  if (organizationUuidsToRevalidate.length > 0) {
+    try {
+      await revalidateOrganizationDocumentClient(organizationUuidsToRevalidate);
+    } catch (error) {
+      Sentry.captureException(error, {
+        tags: {action: 'revalidate-organization-cache'},
+        extra: {organizationUuidsToRevalidate},
+      });
+    }
+  }
 
   return {savedDocument, createdOrganizations: [...createdOrganizations, ...linkedOrganizations]};
 };

--- a/client/src/hooks/mutation/usePutDocument.ts
+++ b/client/src/hooks/mutation/usePutDocument.ts
@@ -1,5 +1,6 @@
 'use client';
 
+import * as Sentry from '@sentry/nextjs';
 import useMutation from '@hooks/useMutation';
 import {DOCUMENT_TYPE, PostDocumentContent, WikiDocument} from '@type/Document.type';
 import useAmplitude from '@hooks/useAmplitude';
@@ -8,6 +9,7 @@ import {
   deleteOrganizationFromDocumentClient,
   linkOrganizationDocumentClient,
   postOrganizationDocumentClient,
+  revalidateOrganizationDocumentClient,
 } from '@apis/client/organization';
 import {useTrie} from '@store/trie';
 import {useDocument} from '@store/document';
@@ -58,6 +60,22 @@ export const usePutDocument = () => {
     await Promise.all(
       deletedOrganizations.map(org => deleteOrganizationFromDocumentClient(savedDocument.documentUUID, org.uuid)),
     );
+
+    const organizationUuidsToRevalidate = [
+      ...createdOrganizations.map(org => org.organizationDocumentUuid),
+      ...linkedOrganizations.map(org => org.organizationDocumentUuid),
+      ...deletedOrganizations.map(org => org.uuid),
+    ];
+    if (organizationUuidsToRevalidate.length > 0) {
+      try {
+        await revalidateOrganizationDocumentClient(organizationUuidsToRevalidate);
+      } catch (error) {
+        Sentry.captureException(error, {
+          tags: {action: 'revalidate-organization-cache'},
+          extra: {organizationUuidsToRevalidate},
+        });
+      }
+    }
 
     return {savedDocument, createdOrganizations: [...createdOrganizations, ...linkedOrganizations]};
   };

--- a/client/src/type/Group.type.ts
+++ b/client/src/type/Group.type.ts
@@ -31,6 +31,11 @@ export interface OrganizationEventResponse {
   occurredAt: string;
 }
 
+export interface LinkedCrewDocumentResponse {
+  documentUuid: string;
+  title: string;
+}
+
 // 조직 문서 및 이벤트 조회 응답 타입
 export interface OrganizationDocumentWithEventsResponse {
   organizationDocumentId: number;
@@ -40,6 +45,7 @@ export interface OrganizationDocumentWithEventsResponse {
   writer: string;
   generateTime: string;
   organizationEventResponses: OrganizationEventResponse[];
+  linkedCrewDocuments: LinkedCrewDocumentResponse[];
 }
 
 // 기존 조직 문서 연결 요청 타입


### PR DESCRIPTION
* chore: develop 브랜치 전략 변경에 따른 워크플로우 및 배포 스크립트 수정

* feat: 조직 문서 페이지에서 연결된 크루 구성원 목록 표시

* feat: 크루 문서 생성/수정 시 연결된 조직 문서 캐시 무효화

* fix: 조직 문서 캐시 무효화 시 발생할 수 있는 런타임 에러 방어 처리

* feat: catch 블록에 에러 로깅 추가

* fix: command injection 차단을 위한 브랜치명 검증 추가

* refactor: Sentry 에러 리포팅 추가

* chore: Close Issue on PR Merge 워크플로우 수정
