### PR TITLE
dev 배포 스크립트 충돌 해결

### DIFF
--- a/.github/workflows/frontend-dev-deploy.yml
+++ b/.github/workflows/frontend-dev-deploy.yml
@@ -83,7 +83,7 @@ jobs:
             echo "🔄 Pulling latest code from Git..."
             # git 충돌 방지를 위한 강제 덮어쓰기
             BRANCH_NAME="${GITHUB_REF#refs/heads/}"
-            git fetch origin "$BRANCH_NAME"
+            git fetch --prune origin
             git reset --hard "origin/$BRANCH_NAME"
 
             echo "📂 Checking build file..."


### PR DESCRIPTION
## issue

- close #218

## 구현 사항

### 오류 발생 상황

`develop` → `develop/v버전명`으로 브랜치 전략을 변경한 이후, dev 배포 스크립트를 실행하면 Deploy on EC2 단계에서 오류가 발생해 실패하는 [문제](https://github.com/Crew-Wiki/crew-wiki-next/actions/runs/23977301995/job/69936255193)가 있었어요(개발 서버가 터진 이유).
이전 PR에서 배포 스크립트를 수정해서 해결될 줄 알았는데([참고 코멘트](https://github.com/Crew-Wiki/crew-wiki-next/pull/215#issuecomment-4110312458)) 여전히 문제가 발생했어요🥲

EC2에 이전 `origin/develop` ref가 남아있어 `origin/develop/v버전명`을 fetch할 때 ref가 충돌하는 것이 원인이었습니다. 
(git은 파일시스템 기반으로 ref를 저장하기 때문에, `develop`이라는 파일이 존재하면 `develop/v3.5.0`이라는 하위 경로를 생성할 수 없어 에러 발생)

### 해결

`git fetch origin "$BRANCH_NAME"` → `git fetch --prune origin`으로 변경했고 
fetch 시 리모트에서 삭제된 브랜치의 stale ref를 전체 정리하도록 했습니다.

## 중점적으로 리뷰받고 싶은 부분(선택)

어떤 부분을 중점으로 리뷰했으면 좋겠는지 작성해주세요.

## 논의하고 싶은 부분(선택)

논의하고 싶은 부분이 있다면 작성해주세요.

## 🫡 참고사항

prod 배포 스크립트는 브랜치명을 main으로 하드코딩하고 있어서 해당 이슈와 관련 없으며 잘 동작합니다.
배포 스크립트는 배포를 해봐야 제대로 동작하는지 잘못됐는지 확인할 수 있어서 불편하네요... 
이 스크립트를 적용해보고 안되면 또 수정하겠습니다🥹
