### PR TITLE
Feat: 전체 문서 조회 api 변경

### DIFF
--- a/.claude/skills/conventions/advanced-patterns.md
+++ b/.claude/skills/conventions/advanced-patterns.md
@@ -410,7 +410,7 @@ import {useTrie} from '@store/trie';
 import {useEffect} from 'react';
 
 const InitTrie = () => {
-  const {data} = useGetDocumentTitleList();      // 전체 문서 {title, uuid}[] 조회
+  const {data} = useGetDocumentTitleList();      // 전체 문서 제목 목록(TitleAndUUID[]) 조회
   const setInit = useTrie(state => state.setInit);
 
   useEffect(() => {

--- a/.claude/skills/conventions/advanced-patterns.md
+++ b/.claude/skills/conventions/advanced-patterns.md
@@ -281,7 +281,7 @@ export const usePutDocument = () => {
 
 ```ts
 // utils/trie.ts
-import {TitleAndUUID} from '@apis/client/document';
+import {TitleAndUUID} from '@type/Document.type';
 
 class Node {
   child: Map<string, Node> = new Map();

--- a/.claude/skills/conventions/api-and-data.md
+++ b/.claude/skills/conventions/api-and-data.md
@@ -196,14 +196,18 @@ export const getDocumentTitlesServer = async () => {
 };
 ```
 
-**제목 목록 타입 구분**:
+**제목 목록 타입 구분** (둘 다 `@type/Document.type.ts`에 선언):
 
 | 타입 | 필드 | 용도 |
 |------|------|------|
 | `TitleAndUUID` | `title`, `uuid`, `documentType` | 검색·자동완성(트라이). 검색(`/document/search`)이 반환하는 최소 필드 |
 | `DocumentTitle` | `TitleAndUUID` + `generateTime` | 전체 제목 목록(`/document/titles`). 관리자 문서 목록 등 편집일이 필요한 경우 |
 
-> `DocumentTitle[]`은 `TitleAndUUID[]`에 할당 가능하므로, 트라이(검색)용 BFF에서는 응답 타입을 `TitleAndUUID[]`로 좁혀 씁니다.
+> 서버 API와 BFF는 실제 응답 그대로 `DocumentTitle[]`을 쓰고, `DocumentTitle[]`은 `TitleAndUUID[]`에 할당 가능하므로 트라이(검색)처럼 `generateTime`이 필요 없는 소비처에서는 `TitleAndUUID[]`로 좁혀 씁니다.
+>
+> 서버·클라이언트 양쪽에서 쓰는 타입이므로 `apis/` 아래가 아니라 공통 타입 파일(`@type/Document.type.ts`)에 선언합니다.
+
+**캐시 무효화**: 문서 생성(post)·수정(put)·삭제(delete) Route Handler에서 모두 `revalidateTag(CACHE.tag.getDocumentTitles)`를 호출합니다. 수정도 `generateTime`을 바꾸므로, 빠뜨리면 관리자 문서 목록의 최근 편집일이 갱신되지 않습니다.
 
 ### Route Handler (BFF)
 

--- a/.claude/skills/conventions/api-and-data.md
+++ b/.claude/skills/conventions/api-and-data.md
@@ -181,6 +181,30 @@ export const postDocumentServer = async (document: PostDocumentContent) => {
 };
 ```
 
+### 목록 조회는 경량 엔드포인트 사용
+
+전체 문서 목록이 필요할 때 본문(`contents`)까지 포함된 전체 문서를 받으면, 문서 수가 많을수록 응답 payload가 커져 Next.js가 파싱에 실패할 수 있습니다. 목록에 필요한 최소 필드만 반환하는 전용 엔드포인트(`/document/titles`)를 사용합니다.
+
+```ts
+// GET: 경량 제목 목록 (본문 제외, ISR 캐시 적용)
+export const getDocumentTitlesServer = async () => {
+  return await requestGetServer<DocumentTitle[]>({
+    baseUrl: process.env.NEXT_PUBLIC_BACKEND_SERVER_BASE_URL,
+    endpoint: ENDPOINT.getDocumentTitles,
+    next: { revalidate: CACHE.time.basicRevalidate, tags: [CACHE.tag.getDocumentTitles] },
+  });
+};
+```
+
+**제목 목록 타입 구분**:
+
+| 타입 | 필드 | 용도 |
+|------|------|------|
+| `TitleAndUUID` | `title`, `uuid`, `documentType` | 검색·자동완성(트라이). 검색(`/document/search`)이 반환하는 최소 필드 |
+| `DocumentTitle` | `TitleAndUUID` + `generateTime` | 전체 제목 목록(`/document/titles`). 관리자 문서 목록 등 편집일이 필요한 경우 |
+
+> `DocumentTitle[]`은 `TitleAndUUID[]`에 할당 가능하므로, 트라이(검색)용 BFF에서는 응답 타입을 `TitleAndUUID[]`로 좁혀 씁니다.
+
 ### Route Handler (BFF)
 
 ```ts

--- a/.claude/skills/conventions/architecture.md
+++ b/.claude/skills/conventions/architecture.md
@@ -152,7 +152,7 @@ route.goWikiEdit(uuid)            // → '/wiki/{uuid}/edit'
 
 ```tsx
 // app/wiki/[uuid]/page.tsx
-import {getDocumentByUUIDServer, getAllDocumentsServer} from '@apis/server/document';
+import {getDocumentByUUIDServer, getDocumentTitlesServer} from '@apis/server/document';
 import DocumentContents from '@components/document/layout/DocumentContents';
 import DocumentFooter from '@components/document/layout/DocumentFooter';
 import DocumentHeader from '@components/document/layout/DocumentHeader';
@@ -168,7 +168,7 @@ export const dynamicParams = true;
 
 export async function generateStaticParams() {
   try {
-    const documents = await getAllDocumentsServer();
+    const documents = await getDocumentTitlesServer();
     if (!documents || !Array.isArray(documents)) return [];
     return documents.map(({uuid}) => ({uuid}));
   } catch (error) {

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -885,14 +885,18 @@ export const getDocumentTitlesServer = async () => {
 };
 ```
 
-**제목 목록 타입 구분**:
+**제목 목록 타입 구분** (둘 다 `@type/Document.type.ts`에 선언):
 
 | 타입 | 필드 | 용도 |
 |------|------|------|
 | `TitleAndUUID` | `title`, `uuid`, `documentType` | 검색·자동완성(트라이). 검색(`/document/search`)이 반환하는 최소 필드 |
 | `DocumentTitle` | `TitleAndUUID` + `generateTime` | 전체 제목 목록(`/document/titles`). 관리자 문서 목록 등 편집일이 필요한 경우 |
 
-> `DocumentTitle[]`은 `TitleAndUUID[]`에 할당 가능하므로, 트라이(검색)용 BFF에서는 응답 타입을 `TitleAndUUID[]`로 좁혀 씁니다.
+> 서버 API와 BFF는 실제 응답 그대로 `DocumentTitle[]`을 쓰고, `DocumentTitle[]`은 `TitleAndUUID[]`에 할당 가능하므로 트라이(검색)처럼 `generateTime`이 필요 없는 소비처에서는 `TitleAndUUID[]`로 좁혀 씁니다.
+>
+> 서버·클라이언트 양쪽에서 쓰는 타입이므로 `apis/` 아래가 아니라 공통 타입 파일(`@type/Document.type.ts`)에 선언합니다.
+
+**캐시 무효화**: 문서 생성(post)·수정(put)·삭제(delete) Route Handler에서 모두 `revalidateTag(CACHE.tag.getDocumentTitles)`를 호출합니다. 수정도 `generateTime`을 바꾸므로, 빠뜨리면 관리자 문서 목록의 최근 편집일이 갱신되지 않습니다.
 
 ### Route Handler (BFF)
 
@@ -1755,7 +1759,7 @@ export const usePutDocument = () => {
 
 ```ts
 // utils/trie.ts
-import {TitleAndUUID} from '@apis/client/document';
+import {TitleAndUUID} from '@type/Document.type';
 
 class Node {
   child: Map<string, Node> = new Map();

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -416,7 +416,7 @@ route.goWikiEdit(uuid)            // → '/wiki/{uuid}/edit'
 
 ```tsx
 // app/wiki/[uuid]/page.tsx
-import {getDocumentByUUIDServer, getAllDocumentsServer} from '@apis/server/document';
+import {getDocumentByUUIDServer, getDocumentTitlesServer} from '@apis/server/document';
 import DocumentContents from '@components/document/layout/DocumentContents';
 import DocumentFooter from '@components/document/layout/DocumentFooter';
 import DocumentHeader from '@components/document/layout/DocumentHeader';
@@ -432,7 +432,7 @@ export const dynamicParams = true;
 
 export async function generateStaticParams() {
   try {
-    const documents = await getAllDocumentsServer();
+    const documents = await getDocumentTitlesServer();
     if (!documents || !Array.isArray(documents)) return [];
     return documents.map(({uuid}) => ({uuid}));
   } catch (error) {

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -870,6 +870,30 @@ export const postDocumentServer = async (document: PostDocumentContent) => {
 };
 ```
 
+### 목록 조회는 경량 엔드포인트 사용
+
+전체 문서 목록이 필요할 때 본문(`contents`)까지 포함된 전체 문서를 받으면, 문서 수가 많을수록 응답 payload가 커져 Next.js가 파싱에 실패할 수 있습니다. 목록에 필요한 최소 필드만 반환하는 전용 엔드포인트(`/document/titles`)를 사용합니다.
+
+```ts
+// GET: 경량 제목 목록 (본문 제외, ISR 캐시 적용)
+export const getDocumentTitlesServer = async () => {
+  return await requestGetServer<DocumentTitle[]>({
+    baseUrl: process.env.NEXT_PUBLIC_BACKEND_SERVER_BASE_URL,
+    endpoint: ENDPOINT.getDocumentTitles,
+    next: { revalidate: CACHE.time.basicRevalidate, tags: [CACHE.tag.getDocumentTitles] },
+  });
+};
+```
+
+**제목 목록 타입 구분**:
+
+| 타입 | 필드 | 용도 |
+|------|------|------|
+| `TitleAndUUID` | `title`, `uuid`, `documentType` | 검색·자동완성(트라이). 검색(`/document/search`)이 반환하는 최소 필드 |
+| `DocumentTitle` | `TitleAndUUID` + `generateTime` | 전체 제목 목록(`/document/titles`). 관리자 문서 목록 등 편집일이 필요한 경우 |
+
+> `DocumentTitle[]`은 `TitleAndUUID[]`에 할당 가능하므로, 트라이(검색)용 BFF에서는 응답 타입을 `TitleAndUUID[]`로 좁혀 씁니다.
+
 ### Route Handler (BFF)
 
 ```ts
@@ -1860,7 +1884,7 @@ import {useTrie} from '@store/trie';
 import {useEffect} from 'react';
 
 const InitTrie = () => {
-  const {data} = useGetDocumentTitleList();      // 전체 문서 {title, uuid}[] 조회
+  const {data} = useGetDocumentTitleList();      // 전체 문서 제목 목록(TitleAndUUID[]) 조회
   const setInit = useTrie(state => state.setInit);
 
   useEffect(() => {

--- a/client/src/apis/client/document.ts
+++ b/client/src/apis/client/document.ts
@@ -3,9 +3,9 @@
 import {CLIENT_ENDPOINT, ENDPOINT} from '@constants/endpoint';
 import {requestGetClient, requestPostClient, requestPutClient, requestDeleteClient} from '@http/client';
 import {
-  DocumentType,
   LatestWikiDocument,
   PostDocumentBody,
+  TitleAndUUID,
   WikiDocument,
   WikiDocumentLogSummary,
 } from '@type/Document.type';
@@ -37,16 +37,6 @@ export const getRandomDocumentClient = async () => {
   });
 
   return document;
-};
-
-export type TitleAndUUID = {
-  title: string;
-  uuid: string;
-  documentType: DocumentType;
-};
-
-export type DocumentTitle = TitleAndUUID & {
-  generateTime: string;
 };
 
 export const getSearchDocumentClient = async (query: string) => {

--- a/client/src/apis/client/document.ts
+++ b/client/src/apis/client/document.ts
@@ -43,6 +43,7 @@ export type TitleAndUUID = {
   title: string;
   uuid: string;
   documentType: DocumentType;
+  generateTime?: string;
 };
 
 export const getSearchDocumentClient = async (query: string) => {

--- a/client/src/apis/client/document.ts
+++ b/client/src/apis/client/document.ts
@@ -43,7 +43,10 @@ export type TitleAndUUID = {
   title: string;
   uuid: string;
   documentType: DocumentType;
-  generateTime?: string;
+};
+
+export type DocumentTitle = TitleAndUUID & {
+  generateTime: string;
 };
 
 export const getSearchDocumentClient = async (query: string) => {

--- a/client/src/apis/server/document.ts
+++ b/client/src/apis/server/document.ts
@@ -3,6 +3,7 @@
 import {CACHE} from '@constants/cache';
 import {ENDPOINT} from '@constants/endpoint';
 import {
+  DocumentTitle,
   PostDocumentBody,
   WikiDocument,
   WikiDocumentExpand,
@@ -14,7 +15,6 @@ import {PaginationParams, PaginationResponse} from '@type/General.type';
 import {documentLogsParams, recentlyParams} from '@constants/params';
 import {ViewCountByUUID} from '@type/viewCount.type';
 import {Organization} from '@type/Group.type';
-import {DocumentTitle} from '@apis/client/document';
 
 export const getDocumentsServerWithPagination = async (params: PaginationParams) => {
   const response = await requestGetServer<PaginationResponse<WikiDocumentExpand[]>>({

--- a/client/src/apis/server/document.ts
+++ b/client/src/apis/server/document.ts
@@ -14,7 +14,7 @@ import {PaginationParams, PaginationResponse} from '@type/General.type';
 import {documentLogsParams, recentlyParams} from '@constants/params';
 import {ViewCountByUUID} from '@type/viewCount.type';
 import {Organization} from '@type/Group.type';
-import {TitleAndUUID} from '@apis/client/document';
+import {DocumentTitle} from '@apis/client/document';
 
 export const getDocumentsServerWithPagination = async (params: PaginationParams) => {
   const response = await requestGetServer<PaginationResponse<WikiDocumentExpand[]>>({
@@ -28,7 +28,7 @@ export const getDocumentsServerWithPagination = async (params: PaginationParams)
 };
 
 export const getDocumentTitlesServer = async () => {
-  const response = await requestGetServer<TitleAndUUID[]>({
+  const response = await requestGetServer<DocumentTitle[]>({
     baseUrl: process.env.NEXT_PUBLIC_BACKEND_SERVER_BASE_URL,
     endpoint: ENDPOINT.getDocumentTitles,
     next: {revalidate: CACHE.time.basicRevalidate, tags: [CACHE.tag.getDocumentTitles]},

--- a/client/src/apis/server/document.ts
+++ b/client/src/apis/server/document.ts
@@ -11,7 +11,7 @@ import {
 } from '@type/Document.type';
 import {requestGetServer, requestPostServer, requestPutServer, requestDeleteServer} from '@http/server';
 import {PaginationParams, PaginationResponse} from '@type/General.type';
-import {allDocumentsParams, documentLogsParams, recentlyParams} from '@constants/params';
+import {documentLogsParams, recentlyParams} from '@constants/params';
 import {ViewCountByUUID} from '@type/viewCount.type';
 import {Organization} from '@type/Group.type';
 import {TitleAndUUID} from '@apis/client/document';
@@ -76,11 +76,6 @@ export const getSpecificDocumentLogServer = async (logId: number) => {
 
 export const getRecentlyDocumentsServer = async () => {
   const response = await getDocumentsServerWithPagination(recentlyParams);
-  return response.data;
-};
-
-export const getAllDocumentsServer = async () => {
-  const response = await getDocumentsServerWithPagination(allDocumentsParams);
   return response.data;
 };
 

--- a/client/src/apis/server/document.ts
+++ b/client/src/apis/server/document.ts
@@ -14,6 +14,7 @@ import {PaginationParams, PaginationResponse} from '@type/General.type';
 import {allDocumentsParams, documentLogsParams, recentlyParams} from '@constants/params';
 import {ViewCountByUUID} from '@type/viewCount.type';
 import {Organization} from '@type/Group.type';
+import {TitleAndUUID} from '@apis/client/document';
 
 export const getDocumentsServerWithPagination = async (params: PaginationParams) => {
   const response = await requestGetServer<PaginationResponse<WikiDocumentExpand[]>>({
@@ -21,6 +22,16 @@ export const getDocumentsServerWithPagination = async (params: PaginationParams)
     endpoint: ENDPOINT.getDocuments,
     queryParams: params,
     next: {revalidate: CACHE.time.basicRevalidate, tags: [CACHE.tag.getDocuments(params)]},
+  });
+
+  return response;
+};
+
+export const getDocumentTitlesServer = async () => {
+  const response = await requestGetServer<TitleAndUUID[]>({
+    baseUrl: process.env.NEXT_PUBLIC_BACKEND_SERVER_BASE_URL,
+    endpoint: ENDPOINT.getDocumentTitles,
+    next: {revalidate: CACHE.time.basicRevalidate, tags: [CACHE.tag.getDocumentTitles]},
   });
 
   return response;

--- a/client/src/app/admin/(admin)/documents/page.tsx
+++ b/client/src/app/admin/(admin)/documents/page.tsx
@@ -4,8 +4,8 @@ import Button from '@components/common/Button';
 import {useState, useEffect, useMemo} from 'react';
 import {useInput} from '@components/common/Input/useInput';
 import {getDocumentTitlesServer} from '@apis/server/document';
-import {deleteDocumentClient, DocumentTitle} from '@apis/client/document';
-import {DOCUMENT_TYPE, DocumentType} from '@type/Document.type';
+import {deleteDocumentClient} from '@apis/client/document';
+import {DOCUMENT_TYPE, DocumentTitle, DocumentType} from '@type/Document.type';
 import {useRouter} from 'next/navigation';
 import {route} from '@constants/route';
 

--- a/client/src/app/admin/(admin)/documents/page.tsx
+++ b/client/src/app/admin/(admin)/documents/page.tsx
@@ -3,22 +3,22 @@
 import Button from '@components/common/Button';
 import {useState, useEffect, useMemo} from 'react';
 import {useInput} from '@components/common/Input/useInput';
-import {getAllDocumentsServer} from '@apis/server/document';
-import {deleteDocumentClient} from '@apis/client/document';
-import {WikiDocumentExpand, DOCUMENT_TYPE, DocumentType} from '@type/Document.type';
+import {getDocumentTitlesServer} from '@apis/server/document';
+import {deleteDocumentClient, TitleAndUUID} from '@apis/client/document';
+import {DOCUMENT_TYPE, DocumentType} from '@type/Document.type';
 import {useRouter} from 'next/navigation';
 import {route} from '@constants/route';
 
 export default function AdminDocumentsPage() {
   const {value, onChange} = useInput({});
   const [currentPage, setCurrentPage] = useState(1);
-  const [documents, setDocuments] = useState<WikiDocumentExpand[]>([]);
+  const [documents, setDocuments] = useState<TitleAndUUID[]>([]);
   const [loading, setLoading] = useState(true);
   const router = useRouter();
 
   const PAGE_SIZE = 10;
 
-  const filterDocumentsByTitle = (docs: WikiDocumentExpand[], searchValue: string) => {
+  const filterDocumentsByTitle = (docs: TitleAndUUID[], searchValue: string) => {
     return docs.filter(document => document.title.toLowerCase().includes(searchValue.toLowerCase()));
   };
 
@@ -80,7 +80,7 @@ export default function AdminDocumentsPage() {
   useEffect(() => {
     const fetchDocuments = async () => {
       try {
-        const allDocs = await getAllDocumentsServer();
+        const allDocs = await getDocumentTitlesServer();
         setDocuments(allDocs);
       } catch (error) {
         console.error('문서를 불러오는데 실패했습니다:', error);
@@ -134,14 +134,16 @@ export default function AdminDocumentsPage() {
           </thead>
           <tbody className="divide-y divide-grayscale-100">
             {paginatedDocuments.map(document => {
-              const latestEditDate = new Date(document.generateTime)
-                .toLocaleDateString('ko-KR', {
-                  year: 'numeric',
-                  month: '2-digit',
-                  day: '2-digit',
-                })
-                .replace(/\. /g, '.')
-                .replace(/\.$/, '');
+              const latestEditDate = document.generateTime
+                ? new Date(document.generateTime)
+                    .toLocaleDateString('ko-KR', {
+                      year: 'numeric',
+                      month: '2-digit',
+                      day: '2-digit',
+                    })
+                    .replace(/\. /g, '.')
+                    .replace(/\.$/, '')
+                : '-';
 
               return (
                 <tr key={document.uuid} className="hover:bg-grayscale-50">

--- a/client/src/app/admin/(admin)/documents/page.tsx
+++ b/client/src/app/admin/(admin)/documents/page.tsx
@@ -4,7 +4,7 @@ import Button from '@components/common/Button';
 import {useState, useEffect, useMemo} from 'react';
 import {useInput} from '@components/common/Input/useInput';
 import {getDocumentTitlesServer} from '@apis/server/document';
-import {deleteDocumentClient, TitleAndUUID} from '@apis/client/document';
+import {deleteDocumentClient, DocumentTitle} from '@apis/client/document';
 import {DOCUMENT_TYPE, DocumentType} from '@type/Document.type';
 import {useRouter} from 'next/navigation';
 import {route} from '@constants/route';
@@ -12,13 +12,13 @@ import {route} from '@constants/route';
 export default function AdminDocumentsPage() {
   const {value, onChange} = useInput({});
   const [currentPage, setCurrentPage] = useState(1);
-  const [documents, setDocuments] = useState<TitleAndUUID[]>([]);
+  const [documents, setDocuments] = useState<DocumentTitle[]>([]);
   const [loading, setLoading] = useState(true);
   const router = useRouter();
 
   const PAGE_SIZE = 10;
 
-  const filterDocumentsByTitle = (docs: TitleAndUUID[], searchValue: string) => {
+  const filterDocumentsByTitle = (docs: DocumentTitle[], searchValue: string) => {
     return docs.filter(document => document.title.toLowerCase().includes(searchValue.toLowerCase()));
   };
 
@@ -134,16 +134,14 @@ export default function AdminDocumentsPage() {
           </thead>
           <tbody className="divide-y divide-grayscale-100">
             {paginatedDocuments.map(document => {
-              const latestEditDate = document.generateTime
-                ? new Date(document.generateTime)
-                    .toLocaleDateString('ko-KR', {
-                      year: 'numeric',
-                      month: '2-digit',
-                      day: '2-digit',
-                    })
-                    .replace(/\. /g, '.')
-                    .replace(/\.$/, '')
-                : '-';
+              const latestEditDate = new Date(document.generateTime)
+                .toLocaleDateString('ko-KR', {
+                  year: 'numeric',
+                  month: '2-digit',
+                  day: '2-digit',
+                })
+                .replace(/\. /g, '.')
+                .replace(/\.$/, '');
 
               return (
                 <tr key={document.uuid} className="hover:bg-grayscale-50">

--- a/client/src/app/api/delete-document/route.ts
+++ b/client/src/app/api/delete-document/route.ts
@@ -11,6 +11,7 @@ const deleteDocument = async (uuid: string, cookieHeader?: string) => {
   const response = await deleteDocumentServer(uuid, cookieHeader);
 
   revalidateTag(CACHE.tag.getRecentlyDocuments);
+  revalidateTag(CACHE.tag.getDocumentTitles);
   revalidateTag(CACHE.tag.getDocumentByUUID(uuid));
 
   return response;

--- a/client/src/app/api/get-document-title-list/route.ts
+++ b/client/src/app/api/get-document-title-list/route.ts
@@ -1,14 +1,14 @@
 'use server';
 
-import {TitleAndUUID} from '@apis/client/document';
 import {getDocumentTitlesServer} from '@apis/server/document';
+import {DocumentTitle} from '@type/Document.type';
 import {ApiResponseType} from '@type/http.type';
 import {NextResponse} from 'next/server';
 
 export const GET = async () => {
   const documents = await getDocumentTitlesServer();
 
-  const response: ApiResponseType<TitleAndUUID[]> = {
+  const response: ApiResponseType<DocumentTitle[]> = {
     data: documents,
     code: 'SUCCESS',
   };

--- a/client/src/app/api/get-document-title-list/route.ts
+++ b/client/src/app/api/get-document-title-list/route.ts
@@ -1,15 +1,15 @@
 'use server';
 
 import {TitleAndUUID} from '@apis/client/document';
-import {getAllDocumentsServer} from '@apis/server/document';
+import {getDocumentTitlesServer} from '@apis/server/document';
 import {ApiResponseType} from '@type/http.type';
 import {NextResponse} from 'next/server';
 
 export const GET = async () => {
-  const documents = await getAllDocumentsServer();
+  const documents = await getDocumentTitlesServer();
 
   const response: ApiResponseType<TitleAndUUID[]> = {
-    data: documents.map(({title, uuid, documentType}) => ({title, uuid, documentType})),
+    data: documents,
     code: 'SUCCESS',
   };
 

--- a/client/src/app/api/post-document/route.ts
+++ b/client/src/app/api/post-document/route.ts
@@ -1,7 +1,6 @@
 'use server';
 
 import {CACHE} from '@constants/cache';
-import {allDocumentsParams} from '@constants/params';
 import {PostDocumentBody, WikiDocument} from '@type/Document.type';
 import {revalidateTag} from 'next/cache';
 import {NextRequest, NextResponse} from 'next/server';
@@ -12,7 +11,6 @@ const postDocument = async (document: PostDocumentBody) => {
   const response = await postDocumentServer(document);
 
   revalidateTag(CACHE.tag.getRecentlyDocuments);
-  revalidateTag(CACHE.tag.getDocuments(allDocumentsParams));
   revalidateTag(CACHE.tag.getDocumentTitles);
   revalidateTag(CACHE.tag.getDocumentByUUID(document.uuid));
   revalidateTag(CACHE.tag.getDocumentLogsByUUID(document.uuid));

--- a/client/src/app/api/post-document/route.ts
+++ b/client/src/app/api/post-document/route.ts
@@ -13,6 +13,7 @@ const postDocument = async (document: PostDocumentBody) => {
 
   revalidateTag(CACHE.tag.getRecentlyDocuments);
   revalidateTag(CACHE.tag.getDocuments(allDocumentsParams));
+  revalidateTag(CACHE.tag.getDocumentTitles);
   revalidateTag(CACHE.tag.getDocumentByUUID(document.uuid));
   revalidateTag(CACHE.tag.getDocumentLogsByUUID(document.uuid));
   revalidateTag(CACHE.tag.getOrganizationsByDocumentUUID(document.uuid));

--- a/client/src/app/api/put-document/route.ts
+++ b/client/src/app/api/put-document/route.ts
@@ -11,6 +11,7 @@ const putDocument = async (document: PostDocumentBody) => {
   const response = await putDocumentServer(document);
 
   revalidateTag(CACHE.tag.getRecentlyDocuments);
+  revalidateTag(CACHE.tag.getDocumentTitles);
   revalidateTag(CACHE.tag.getDocumentByUUID(document.uuid));
   revalidateTag(CACHE.tag.getDocumentLogsByUUID(document.uuid));
   revalidateTag(CACHE.tag.getOrganizationsByDocumentUUID(document.uuid));

--- a/client/src/app/wiki/[uuid]/page.tsx
+++ b/client/src/app/wiki/[uuid]/page.tsx
@@ -1,6 +1,6 @@
 import {
   getDocumentByUUIDServer,
-  getAllDocumentsServer,
+  getDocumentTitlesServer,
   getOrganizationDocumentsByDocumentUUIDServer,
 } from '@apis/server/document';
 import DocumentContents from '@components/document/layout/DocumentContents';
@@ -19,7 +19,7 @@ export const dynamicParams = true;
 
 export async function generateStaticParams() {
   try {
-    const documents = await getAllDocumentsServer();
+    const documents = await getDocumentTitlesServer();
 
     if (!documents || !Array.isArray(documents)) return [];
 

--- a/client/src/components/common/SearchTerms/RelativeSearchTerms.tsx
+++ b/client/src/components/common/SearchTerms/RelativeSearchTerms.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import {TitleAndUUID} from '@apis/client/document';
+import {TitleAndUUID} from '@type/Document.type';
 
 interface RelativeSearchTermsProps {
   style?: React.CSSProperties;

--- a/client/src/components/document/Write/OrganizationInputField.tsx
+++ b/client/src/components/document/Write/OrganizationInputField.tsx
@@ -7,8 +7,7 @@ import Button from '@components/common/Button';
 import {Chip} from '@components/common/Chip';
 import RelativeSearchTerms from '@components/common/SearchTerms/RelativeSearchTerms';
 import {useTrie} from '@store/trie';
-import {TitleAndUUID} from '@apis/client/document';
-import {DOCUMENT_TYPE} from '@type/Document.type';
+import {DOCUMENT_TYPE, TitleAndUUID} from '@type/Document.type';
 import {Organization} from '@type/Group.type';
 
 interface OrganizationInputFieldProps {

--- a/client/src/constants/cache.ts
+++ b/client/src/constants/cache.ts
@@ -24,6 +24,7 @@ export const CACHE = {
   tag: {
     getDocuments: (params: PaginationParams) => TAG_PREFIX + generatePaginationCacheTags(params, 'documents'),
     getRecentlyDocuments: TAG_PREFIX + generatePaginationCacheTags(recentlyParams, 'documents'),
+    getDocumentTitles: TAG_PREFIX + 'document-titles',
     getDocumentByTitle: (title: string) => TAG_PREFIX + `title:${decodeURI(title)}`,
     getDocumentByUUID: (uuid: string) => TAG_PREFIX + `title:${uuid}`,
     getDocumentLogsByUUID: (uuid: string) => TAG_PREFIX + `logs:${uuid}`,

--- a/client/src/constants/endpoint.ts
+++ b/client/src/constants/endpoint.ts
@@ -3,6 +3,7 @@ export const ENDPOINT = {
   postDocument: '/document',
   updateDocument: '/document',
   getDocuments: '/document',
+  getDocumentTitles: '/document/titles',
   getDocumentByTitle: (title: string) => `/document/title/${title}`,
   getDocumentByUUID: (uuid: string) => `/document/uuid/${uuid}`,
   getRandomDocument: '/document/random',

--- a/client/src/constants/params.ts
+++ b/client/src/constants/params.ts
@@ -7,13 +7,6 @@ export const recentlyParams: PaginationParams = {
   sortDirection: 'DESC',
 };
 
-export const allDocumentsParams: PaginationParams = {
-  pageNumber: 0,
-  pageSize: 10000, // 임의로 10000으로 설정, 나중에 전체 크기를 알 수 있는 api 필요
-  sort: 'generateTime',
-  sortDirection: 'ASC',
-};
-
 export const documentLogsParams: PaginationParams = {
   pageNumber: 0,
   pageSize: 10,

--- a/client/src/hooks/fetch/useGetDocumentTitleList.ts
+++ b/client/src/hooks/fetch/useGetDocumentTitleList.ts
@@ -1,5 +1,6 @@
-import {getDocumentTitleListClient, TitleAndUUID} from '@apis/client/document';
+import {getDocumentTitleListClient} from '@apis/client/document';
 import {useFetch} from '@hooks/useFetch';
+import {TitleAndUUID} from '@type/Document.type';
 
 export const useGetDocumentTitleList = () => {
   const {data} = useFetch<TitleAndUUID[]>(getDocumentTitleListClient);

--- a/client/src/store/trie.ts
+++ b/client/src/store/trie.ts
@@ -1,5 +1,4 @@
-import {TitleAndUUID} from '@apis/client/document';
-import {DocumentType} from '@type/Document.type';
+import {DocumentType, TitleAndUUID} from '@type/Document.type';
 import {Trie} from '@utils/trie';
 import {create} from 'zustand';
 

--- a/client/src/type/Document.type.ts
+++ b/client/src/type/Document.type.ts
@@ -8,6 +8,16 @@ export const DOCUMENT_TYPE = {
 
 export type DocumentType = (typeof DOCUMENT_TYPE)[keyof typeof DOCUMENT_TYPE];
 
+export type TitleAndUUID = {
+  title: string;
+  uuid: string;
+  documentType: DocumentType;
+};
+
+export type DocumentTitle = TitleAndUUID & {
+  generateTime: string;
+};
+
 export interface WikiDocument {
   documentId: number;
   documentUUID: string;

--- a/client/src/utils/trie.ts
+++ b/client/src/utils/trie.ts
@@ -1,5 +1,4 @@
-import {TitleAndUUID} from '@apis/client/document';
-import {DOCUMENT_TYPE, DocumentType} from '@type/Document.type';
+import {DOCUMENT_TYPE, DocumentType, TitleAndUUID} from '@type/Document.type';
 
 class Node {
   child: Map<string, Node> = new Map();


### PR DESCRIPTION
## issue

- close #221

## 구현 사항

`getAllDocumentsServer`에 `allDocumentsParams`(pageSize 10000)를 넘겨 전체 문서를 **본문(`contents`)까지 포함**해 한 번에 불러오면, 문서 수가 많을수록 응답 payload가 커져 Next.js가 파싱에 실패하는 문제가 있었습니다.

이를 해결하기 위해 백엔드에 제목 목록 전용 엔드포인트 `GET /document/titles`(`title`, `uuid`, `documentType`, `generateTime` 반환)가 추가되었고, 이 엔드포인트에 대응하도록 했습니다.

- 참고(백엔드): Crew-Wiki/backend#168 (`/document/titles` 추가), Crew-Wiki/backend#170 (`documentType`, `generateTime` 필드 추가)

## 🫡 참고사항
-
